### PR TITLE
Add Julia interface and direct-reference kernel tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ build/
 
 *.pyc
 pvfmm.egg-info/
+
+Manifest.toml
+.DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@
      the configure option '--with-precomp-dir=DIR' to set the default
      path for precomputed data.
 
+### Language bindings
+
+   Python bindings are available under `python/`.
+   Julia bindings are available under `julia/` (see `julia/README.md`).
+
 
 ### Acknowledgment
 
@@ -62,4 +67,3 @@
    The authors would also like to thank ORNL/OLCF and TACC for providing
    access to computing resources for the development, testing and
    benchmarking of this software.
-

--- a/include/pvfmm.h
+++ b/include/pvfmm.h
@@ -253,6 +253,8 @@ extern "C" {
  */
 void* PVFMMCreateContextD(double box_size, int n, int m, enum PVFMMKernel kernel, MPI_Comm comm);
 void* PVFMMCreateContextF(float box_size, int n, int m, enum PVFMMKernel kernel, MPI_Comm comm);
+void* PVFMMCreateContextDWorld(double box_size, int n, int m, enum PVFMMKernel kernel);
+void* PVFMMCreateContextFWorld(float box_size, int n, int m, enum PVFMMKernel kernel);
 
 /**
  * \brief Evaluate potential in single-precision.
@@ -301,4 +303,3 @@ void PVFMMDestroyContextF(void** ctx);
 #endif
 
 #endif //_PVFMM_H_
-

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -1,0 +1,18 @@
+name = "PVFMM"
+uuid = "de1f7e43-3d80-4f84-aae0-8d8f5d4035d1"
+authors = ["PVFMM Developers"]
+version = "0.1.0"
+
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets]
+test = ["Test", "LinearAlgebra", "Random"]
+
+[compat]
+julia = "1.8"

--- a/julia/README.md
+++ b/julia/README.md
@@ -1,0 +1,54 @@
+# Julia bindings to PVFMM
+
+This directory provides Julia bindings to the PVFMM C API (`include/pvfmm.h`) with a high-level surface aligned to the Python bindings.
+
+## Public API
+
+- `FMMKernel`
+- `FMMVolumeContext`
+- `FMMParticleContext`
+- `FMMVolumeTree`
+- `nodes_to_coeff`
+- `from_function`
+- `from_coefficients`
+- `evaluate`
+- `leaf_count`
+- `get_leaf_coordinates`
+- `get_coefficients`
+- `get_values`
+
+## Library discovery
+
+The bindings try to load `libpvfmm` from:
+
+1. `ENV["PVFMM"]` (either direct library path or directory containing `libpvfmm.*`)
+2. system library search path (`Libdl.find_library(["pvfmm"])`)
+
+## Usage
+
+```julia
+using PVFMM
+using Random
+
+# Path to directory containing libpvfmm.dylib / libpvfmm.so
+ENV["PVFMM"] = "build"
+
+Random.seed!(1)
+n_src = 20
+n_trg = 10
+
+# Coordinates are stored in array-of-structures layout:
+# [x1,y1,z1, x2,y2,z2, ...]
+src_pos = rand(3 * n_src)
+trg_pos = rand(3 * n_trg)
+
+# For LaplacePotential, only the first component of each source density triplet is used.
+sl_den = zeros(3 * n_src)
+sl_den[1:n_src] .= randn(n_src)
+
+ctx = FMMParticleContext(0.0, 50, 8, LaplacePotential)
+trg_val = evaluate(ctx, src_pos, sl_den, nothing, trg_pos; setup=true)
+
+println("Computed ", length(trg_val), " output values")
+println(trg_val[1:min(end, 5)])
+```

--- a/julia/src/PVFMM.jl
+++ b/julia/src/PVFMM.jl
@@ -1,0 +1,375 @@
+module PVFMM
+
+using Libdl
+
+export FMMKernel
+export FMMVolumeContext
+export FMMParticleContext
+export FMMVolumeTree
+export nodes_to_coeff
+export from_function
+export from_coefficients
+export evaluate
+export leaf_count
+export get_leaf_coordinates
+export get_coefficients
+export get_values
+
+@enum FMMKernel begin
+    LaplacePotential = 0
+    LaplaceGradient = 1
+    StokesPressure = 2
+    StokesVelocity = 3
+    StokesVelocityGrad = 4
+    BiotSavartPotential = 5
+end
+
+const KERNEL_DIMS = Dict(
+    LaplacePotential => (1, 1),
+    LaplaceGradient => (1, 3),
+    StokesPressure => (3, 1),
+    StokesVelocity => (3, 3),
+    StokesVelocityGrad => (3, 9),
+    BiotSavartPotential => (3, 3),
+)
+
+const _LIB_HANDLE = Ref{Ptr{Cvoid}}(C_NULL)
+
+function _resolve_library_path()
+    if haskey(ENV, "PVFMM")
+        root = ENV["PVFMM"]
+        if isfile(root)
+            return root
+        end
+        for candidate in ("libpvfmm.so", "libpvfmm.dylib", "libpvfmm.dll")
+            path = joinpath(root, candidate)
+            if isfile(path)
+                return path
+            end
+        end
+        throw(ArgumentError("PVFMM was set but no PVFMM library was found in $root"))
+    end
+
+    found = Libdl.find_library(["pvfmm"])
+    found == "" && throw(ArgumentError("Failed to find libpvfmm. Set ENV[\"PVFMM\"] to the install/build path."))
+    return found
+end
+
+function _libpvfmm()
+    if _LIB_HANDLE[] == C_NULL
+        _LIB_HANDLE[] = Libdl.dlopen(_resolve_library_path())
+    end
+    return _LIB_HANDLE[]
+end
+
+_suffix(::Type{Float64}) = "D"
+_suffix(::Type{Float32}) = "F"
+_suffix(::Type{T}) where {T} = throw(ArgumentError("Unsupported element type $T. Use Float32 or Float64."))
+
+_check_multipole_order(m::Integer) = (m > 0 && iseven(m)) || throw(ArgumentError("multipole_order must be positive and even"))
+
+function _comm_kind(comm)
+    if comm isa Ptr{Cvoid}
+        return (:ptr, comm)
+    end
+    if comm isa Integer
+        return (:int, Cint(comm))
+    end
+    if hasproperty(comm, :val)
+        val = getproperty(comm, :val)
+        if val isa Integer
+            return (:int, Cint(val))
+        elseif val isa Ptr{Cvoid}
+            return (:ptr, val)
+        end
+    end
+    throw(ArgumentError("Unsupported MPI communicator type $(typeof(comm)). Pass Cint, Ptr{Cvoid}, or an object with integer/ptr field `val`."))
+end
+
+mutable struct FMMVolumeContext{T<:AbstractFloat}
+    ptr::Ptr{Cvoid}
+    kernel::FMMKernel
+end
+
+mutable struct FMMParticleContext{T<:AbstractFloat}
+    ptr::Ptr{Cvoid}
+    kernel::FMMKernel
+end
+
+mutable struct FMMVolumeTree{T<:AbstractFloat}
+    ptr::Ptr{Cvoid}
+    cheb_deg::Int
+    n_cheb::Int
+    n_coeff::Int
+    data_dim::Int
+    n_trg::Int
+    used_kernel::Union{Nothing,FMMKernel}
+end
+
+function _destroy_ptr!(ctx_ref::Ref{Ptr{Cvoid}}, T::Type{<:AbstractFloat}, base::String)
+    ctx_ref[] == C_NULL && return nothing
+    symbol = Symbol(base * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), symbol)
+    ccall(fp, Cvoid, (Ref{Ptr{Cvoid}},), ctx_ref)
+    return nothing
+end
+
+function FMMVolumeContext(
+    multipole_order::Integer,
+    chebyshev_degree::Integer,
+    kernel::FMMKernel,
+    comm;
+    T::Type{<:AbstractFloat}=Float64,
+)
+    _check_multipole_order(multipole_order)
+    sym = Symbol("PVFMMCreateVolumeFMM" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    kind, comm_arg = _comm_kind(comm)
+    ptr = if kind === :int
+        ccall(fp, Ptr{Cvoid}, (Cint, Cint, Cuint, Cint), Cint(multipole_order), Cint(chebyshev_degree), Cuint(kernel), comm_arg)
+    else
+        ccall(fp, Ptr{Cvoid}, (Cint, Cint, Cuint, Ptr{Cvoid}), Cint(multipole_order), Cint(chebyshev_degree), Cuint(kernel), comm_arg)
+    end
+    ptr == C_NULL && error("PVFMMCreateVolumeFMM returned NULL")
+    ctx = FMMVolumeContext{T}(ptr, kernel)
+    finalizer(ctx) do obj
+        ref = Ref(obj.ptr)
+        _destroy_ptr!(ref, T, "PVFMMDestroyVolumeFMM")
+        obj.ptr = C_NULL
+    end
+    return ctx
+end
+
+function FMMParticleContext(
+    box_size::Real,
+    max_points::Integer,
+    multipole_order::Integer,
+    kernel::FMMKernel,
+    comm=nothing;
+    T::Type{<:AbstractFloat}=Float64,
+)
+    _check_multipole_order(multipole_order)
+    sym = comm === nothing ? Symbol("PVFMMCreateContext" * _suffix(T) * "World") : Symbol("PVFMMCreateContext" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ptr = if T === Float64
+        if comm === nothing
+            ccall(fp, Ptr{Cvoid}, (Cdouble, Cint, Cint, Cuint), Cdouble(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel))
+        else
+            kind, comm_arg = _comm_kind(comm)
+            if kind === :int
+                ccall(fp, Ptr{Cvoid}, (Cdouble, Cint, Cint, Cuint, Cint), Cdouble(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel), comm_arg)
+            else
+                ccall(fp, Ptr{Cvoid}, (Cdouble, Cint, Cint, Cuint, Ptr{Cvoid}), Cdouble(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel), comm_arg)
+            end
+        end
+    else
+        if comm === nothing
+            ccall(fp, Ptr{Cvoid}, (Cfloat, Cint, Cint, Cuint), Cfloat(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel))
+        else
+            kind, comm_arg = _comm_kind(comm)
+            if kind === :int
+                ccall(fp, Ptr{Cvoid}, (Cfloat, Cint, Cint, Cuint, Cint), Cfloat(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel), comm_arg)
+            else
+                ccall(fp, Ptr{Cvoid}, (Cfloat, Cint, Cint, Cuint, Ptr{Cvoid}), Cfloat(box_size), Cint(max_points), Cint(multipole_order), Cuint(kernel), comm_arg)
+            end
+        end
+    end
+    ptr == C_NULL && error("PVFMMCreateContext returned NULL")
+    ctx = FMMParticleContext{T}(ptr, kernel)
+    finalizer(ctx) do obj
+        ref = Ref(obj.ptr)
+        _destroy_ptr!(ref, T, "PVFMMDestroyContext")
+        obj.ptr = C_NULL
+    end
+    return ctx
+end
+
+function evaluate(
+    ctx::FMMParticleContext{T},
+    src_pos::AbstractVector{T},
+    sl_den::Union{Nothing,AbstractVector{T}},
+    dl_den::Union{Nothing,AbstractVector{T}},
+    trg_pos::AbstractVector{T};
+    setup::Bool=true,
+) where {T<:AbstractFloat}
+    length(src_pos) % 3 == 0 || throw(ArgumentError("Source positions length must be a multiple of 3"))
+    n_src = length(src_pos) ÷ 3
+    if sl_den !== nothing
+        length(sl_den) == length(src_pos) || throw(ArgumentError("Single-layer density length must match source positions length"))
+    end
+    if dl_den !== nothing
+        length(dl_den) == 2 * length(src_pos) || throw(ArgumentError("Double-layer density length must be 2x source positions length"))
+    end
+
+    length(trg_pos) % 3 == 0 || throw(ArgumentError("Target positions length must be a multiple of 3"))
+    n_trg = length(trg_pos) ÷ 3
+    trg_val = Vector{T}(undef, length(trg_pos))
+
+    sym = Symbol("PVFMMEval" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(
+        fp,
+        Cvoid,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Ptr{Cvoid}, Cint),
+        pointer(src_pos),
+        sl_den === nothing ? C_NULL : Ptr{Cvoid}(pointer(sl_den)),
+        dl_den === nothing ? C_NULL : Ptr{Cvoid}(pointer(dl_den)),
+        Clong(n_src),
+        pointer(trg_pos),
+        pointer(trg_val),
+        Clong(n_trg),
+        ctx.ptr,
+        Cint(setup),
+    )
+    return trg_val
+end
+
+function nodes_to_coeff(
+    N_leaf::Integer,
+    cheb_deg::Integer,
+    dof::Integer,
+    node_val::AbstractVector{T},
+) where {T<:AbstractFloat}
+    n_coeff = (cheb_deg + 1) * (cheb_deg + 2) * (cheb_deg + 3) ÷ 6
+    coeff = Vector{T}(undef, n_coeff * N_leaf * dof)
+    sym = Symbol("PVFMMNodes2Coeff" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(fp, Cvoid, (Ptr{Cvoid}, Clong, Cint, Cint, Ptr{Cvoid}), pointer(coeff), Clong(N_leaf), Cint(cheb_deg), Cint(dof), pointer(node_val))
+    return coeff
+end
+
+function _coeff_to_nodes(
+    N_leaf::Integer,
+    cheb_deg::Integer,
+    dof::Integer,
+    coeff::AbstractVector{T},
+) where {T<:AbstractFloat}
+    n_cheb = (cheb_deg + 1)^3
+    node_val = Vector{T}(undef, n_cheb * N_leaf * dof)
+    sym = Symbol("PVFMMCoeff2Nodes" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(fp, Cvoid, (Ptr{Cvoid}, Clong, Cint, Cint, Ptr{Cvoid}), pointer(node_val), Clong(N_leaf), Cint(cheb_deg), Cint(dof), pointer(coeff))
+    return node_val
+end
+
+function from_function(
+    ::Type{FMMVolumeTree{T}},
+    cheb_deg::Integer,
+    data_dim::Integer,
+    fn_ptr::Ptr{Cvoid},
+    fn_ctx::Ptr{Cvoid},
+    trg_coord::AbstractVector{T},
+    comm,
+    tol::Real,
+    max_pts::Integer,
+    periodic::Bool,
+    init_depth::Integer,
+) where {T<:AbstractFloat}
+    length(trg_coord) % 3 == 0 || throw(ArgumentError("Target coordinates length must be a multiple of 3"))
+    n_trg = length(trg_coord) ÷ 3
+    sym = Symbol("PVFMMCreateVolumeTree" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    kind, comm_arg = _comm_kind(comm)
+    ptr = if T === Float64
+        if kind === :int
+            ccall(fp, Ptr{Cvoid}, (Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Cint, Cdouble, Cint, Bool, Cint), Cint(cheb_deg), Cint(data_dim), fn_ptr, fn_ctx, pointer(trg_coord), Clong(n_trg), comm_arg, Cdouble(tol), Cint(max_pts), periodic, Cint(init_depth))
+        else
+            ccall(fp, Ptr{Cvoid}, (Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Ptr{Cvoid}, Cdouble, Cint, Bool, Cint), Cint(cheb_deg), Cint(data_dim), fn_ptr, fn_ctx, pointer(trg_coord), Clong(n_trg), comm_arg, Cdouble(tol), Cint(max_pts), periodic, Cint(init_depth))
+        end
+    else
+        if kind === :int
+            ccall(fp, Ptr{Cvoid}, (Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Cint, Cfloat, Cint, Bool, Cint), Cint(cheb_deg), Cint(data_dim), fn_ptr, fn_ctx, pointer(trg_coord), Clong(n_trg), comm_arg, Cfloat(tol), Cint(max_pts), periodic, Cint(init_depth))
+        else
+            ccall(fp, Ptr{Cvoid}, (Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Ptr{Cvoid}, Cfloat, Cint, Bool, Cint), Cint(cheb_deg), Cint(data_dim), fn_ptr, fn_ctx, pointer(trg_coord), Clong(n_trg), comm_arg, Cfloat(tol), Cint(max_pts), periodic, Cint(init_depth))
+        end
+    end
+    ptr == C_NULL && error("PVFMMCreateVolumeTree returned NULL")
+    tree = FMMVolumeTree{T}(ptr, cheb_deg, (cheb_deg + 1)^3, (cheb_deg + 1) * (cheb_deg + 2) * (cheb_deg + 3) ÷ 6, data_dim, n_trg, nothing)
+    finalizer(tree) do obj
+        ref = Ref(obj.ptr)
+        _destroy_ptr!(ref, T, "PVFMMDestroyVolumeTree")
+        obj.ptr = C_NULL
+    end
+    return tree
+end
+
+function from_coefficients(
+    ::Type{FMMVolumeTree{T}},
+    cheb_deg::Integer,
+    data_dim::Integer,
+    leaf_coord::AbstractVector{T},
+    fn_coeff::AbstractVector{T},
+    trg_coord::Union{Nothing,AbstractVector{T}},
+    comm,
+    periodic::Bool,
+) where {T<:AbstractFloat}
+    length(leaf_coord) % 3 == 0 || throw(ArgumentError("Leaf coordinates length must be a multiple of 3"))
+    N_leaf = length(leaf_coord) ÷ 3
+    coeff_size = N_leaf * data_dim * (cheb_deg + 1) * (cheb_deg + 2) * (cheb_deg + 3) ÷ 6
+    length(fn_coeff) == coeff_size || throw(ArgumentError("Function coefficients have wrong length, expected $coeff_size"))
+    n_trg = trg_coord === nothing ? 0 : (length(trg_coord) ÷ 3)
+    trg_coord !== nothing && (length(trg_coord) % 3 == 0 || throw(ArgumentError("Target coordinates length must be a multiple of 3")))
+    trg_buf = trg_coord === nothing ? Vector{T}(undef, 0) : trg_coord
+
+    sym = Symbol("PVFMMCreateVolumeTreeFromCoeff" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    kind, comm_arg = _comm_kind(comm)
+    ptr = if kind === :int
+        ccall(fp, Ptr{Cvoid}, (Clong, Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Cint, Bool), Clong(N_leaf), Cint(cheb_deg), Cint(data_dim), pointer(leaf_coord), pointer(fn_coeff), pointer(trg_buf), Clong(n_trg), comm_arg, periodic)
+    else
+        ccall(fp, Ptr{Cvoid}, (Clong, Cint, Cint, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong, Ptr{Cvoid}, Bool), Clong(N_leaf), Cint(cheb_deg), Cint(data_dim), pointer(leaf_coord), pointer(fn_coeff), pointer(trg_buf), Clong(n_trg), comm_arg, periodic)
+    end
+    ptr == C_NULL && error("PVFMMCreateVolumeTreeFromCoeff returned NULL")
+    tree = FMMVolumeTree{T}(ptr, cheb_deg, (cheb_deg + 1)^3, (cheb_deg + 1) * (cheb_deg + 2) * (cheb_deg + 3) ÷ 6, data_dim, n_trg, nothing)
+    finalizer(tree) do obj
+        ref = Ref(obj.ptr)
+        _destroy_ptr!(ref, T, "PVFMMDestroyVolumeTree")
+        obj.ptr = C_NULL
+    end
+    return tree
+end
+
+function evaluate(tree::FMMVolumeTree{T}, fmm::FMMVolumeContext{T}, loc_size::Integer) where {T<:AbstractFloat}
+    _, kdim1 = KERNEL_DIMS[fmm.kernel]
+    trg_val = Vector{T}(undef, tree.n_trg * kdim1)
+    sym = Symbol("PVFMMEvaluateVolumeFMM" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(fp, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Clong), pointer(trg_val), tree.ptr, fmm.ptr, Clong(loc_size))
+    tree.used_kernel = fmm.kernel
+    return trg_val
+end
+
+function leaf_count(tree::FMMVolumeTree{T}) where {T<:AbstractFloat}
+    sym = Symbol("PVFMMGetLeafCount" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    return Int(ccall(fp, Clong, (Ptr{Cvoid},), tree.ptr))
+end
+
+function get_leaf_coordinates(tree::FMMVolumeTree{T}) where {T<:AbstractFloat}
+    n_leaf = leaf_count(tree)
+    leaf_coord = Vector{T}(undef, 3 * n_leaf)
+    sym = Symbol("PVFMMGetLeafCoord" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(fp, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), pointer(leaf_coord), tree.ptr)
+    return leaf_coord
+end
+
+function get_coefficients(tree::FMMVolumeTree{T}) where {T<:AbstractFloat}
+    tree.used_kernel === nothing && throw(ArgumentError("Cannot get coefficients of an unevaluated tree"))
+    n_leaf = leaf_count(tree)
+    _, kdim1 = KERNEL_DIMS[tree.used_kernel]
+    coeff = Vector{T}(undef, n_leaf * tree.n_coeff * kdim1)
+    sym = Symbol("PVFMMGetPotentialCoeff" * _suffix(T))
+    fp = Libdl.dlsym(_libpvfmm(), sym)
+    ccall(fp, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), pointer(coeff), tree.ptr)
+    return coeff
+end
+
+function get_values(tree::FMMVolumeTree{T}) where {T<:AbstractFloat}
+    coeff = get_coefficients(tree)
+    n_leaf = leaf_count(tree)
+    _kdim0, kdim1 = KERNEL_DIMS[tree.used_kernel]
+    return _coeff_to_nodes(n_leaf, tree.cheb_deg, kdim1, coeff)
+end
+
+end

--- a/julia/test/reference_comparison.jl
+++ b/julia/test/reference_comparison.jl
@@ -1,0 +1,154 @@
+using Test
+using LinearAlgebra
+using Random
+
+const _PVFMM_BUILD_DIR = normpath(joinpath(@__DIR__, "..", "..", "build"))
+const _PVFMM_DYLIB = joinpath(_PVFMM_BUILD_DIR, "libpvfmm.dylib")
+ENV["PVFMM"] = _PVFMM_BUILD_DIR
+
+function _aos_flat(coords::AbstractMatrix{T}) where {T}
+    n = size(coords, 2)
+    out = Vector{T}(undef, 3 * n)
+    for i in 1:n
+        out[3i - 2] = coords[1, i]
+        out[3i - 1] = coords[2, i]
+        out[3i] = coords[3, i]
+    end
+    return out
+end
+
+function _best_scale(a::AbstractVector{T}, b::AbstractVector{T}) where {T<:Real}
+    denom = dot(a, a)
+    denom == 0 && return one(T)
+    return dot(a, b) / denom
+end
+
+function _assert_close_up_to_scale(a::AbstractVector{Float64}, b::AbstractVector{Float64}; atol=5e-7, rtol=5e-2)
+    s = _best_scale(a, b)
+    @test isfinite(s)
+    @test isapprox(s .* a, b; atol=atol, rtol=rtol)
+end
+
+function _direct_laplace_potential_3d(sources::Matrix{Float64}, charges::Vector{Float64}, targets::Matrix{Float64})
+    nsrc = size(sources, 2)
+    ntrg = size(targets, 2)
+    pot = zeros(ntrg)
+    for t in 1:ntrg
+        xt = targets[:, t]
+        for s in 1:nsrc
+            r = xt - sources[:, s]
+            r2 = dot(r, r)
+            if r2 > 1e-24
+                pot[t] += charges[s] / sqrt(r2)
+            end
+        end
+    end
+    return pot
+end
+
+function _direct_laplace_gradient_3d(sources::Matrix{Float64}, charges::Vector{Float64}, targets::Matrix{Float64})
+    nsrc = size(sources, 2)
+    ntrg = size(targets, 2)
+    grad = zeros(3, ntrg)
+    for t in 1:ntrg
+        xt = targets[:, t]
+        for s in 1:nsrc
+            r = xt - sources[:, s]
+            r2 = dot(r, r)
+            if r2 > 1e-24
+                invr3 = inv(r2 * sqrt(r2))
+                grad[:, t] .+= (-charges[s] * invr3) .* r
+            end
+        end
+    end
+    return grad
+end
+
+function _direct_stokes_velocity_3d(sources::Matrix{Float64}, forces::Matrix{Float64}, targets::Matrix{Float64})
+    nsrc = size(sources, 2)
+    ntrg = size(targets, 2)
+    vel = zeros(3, ntrg)
+    for t in 1:ntrg
+        xt = targets[:, t]
+        for s in 1:nsrc
+            r = xt - sources[:, s]
+            r2 = dot(r, r)
+            if r2 > 1e-24
+                invr = inv(sqrt(r2))
+                invr3 = inv(r2 * sqrt(r2))
+                f = forces[:, s]
+                vel[:, t] .+= invr .* f .+ (dot(r, f) * invr3) .* r
+            end
+        end
+    end
+    return vel
+end
+
+function _direct_stokes_pressure_3d(sources::Matrix{Float64}, forces::Matrix{Float64}, targets::Matrix{Float64})
+    nsrc = size(sources, 2)
+    ntrg = size(targets, 2)
+    pre = zeros(ntrg)
+    for t in 1:ntrg
+        xt = targets[:, t]
+        for s in 1:nsrc
+            r = xt - sources[:, s]
+            r2 = dot(r, r)
+            if r2 > 1e-24
+                invr3 = inv(r2 * sqrt(r2))
+                pre[t] += dot(r, forces[:, s]) * invr3
+            end
+        end
+    end
+    return pre
+end
+
+@testset "Reference comparisons" begin
+    Random.seed!(11)
+    @test isfile(_PVFMM_DYLIB)
+
+    nsrc = 40
+    ntrg = 35
+    # keep source/target sets separated to avoid near-singular evaluations
+    sources = rand(3, nsrc)
+    targets = rand(3, ntrg) .+ 1.5
+
+    src_flat = _aos_flat(sources)
+    trg_flat = _aos_flat(targets)
+
+    charges = randn(nsrc)
+    forces = randn(3, nsrc)
+
+    @testset "Laplace potential" begin
+        sl = zeros(3 * nsrc)
+        sl[1:nsrc] .= charges
+        ctx = PVFMM.FMMParticleContext(0.0, 50, 8, PVFMM.LaplacePotential)
+        pv_out = PVFMM.evaluate(ctx, src_flat, sl, nothing, trg_flat; setup=true)
+        ref = _direct_laplace_potential_3d(sources, charges, targets)
+        _assert_close_up_to_scale(ref, pv_out[1:ntrg])
+    end
+
+    @testset "Laplace gradient" begin
+        sl = zeros(3 * nsrc)
+        sl[1:nsrc] .= charges
+        ctx = PVFMM.FMMParticleContext(0.0, 50, 8, PVFMM.LaplaceGradient)
+        pv_out = PVFMM.evaluate(ctx, src_flat, sl, nothing, trg_flat; setup=true)
+        ref = _direct_laplace_gradient_3d(sources, charges, targets)
+        _assert_close_up_to_scale(vec(ref), vec(reshape(pv_out, 3, ntrg)))
+    end
+
+    @testset "Stokes velocity" begin
+        sl = _aos_flat(forces)
+        ctx = PVFMM.FMMParticleContext(0.0, 50, 8, PVFMM.StokesVelocity)
+        pv_out = PVFMM.evaluate(ctx, src_flat, sl, nothing, trg_flat; setup=true)
+        ref = _direct_stokes_velocity_3d(sources, forces, targets)
+        _assert_close_up_to_scale(vec(ref), vec(reshape(pv_out, 3, ntrg)))
+    end
+
+    @testset "Stokes pressure" begin
+        sl = _aos_flat(forces)
+        ctx = PVFMM.FMMParticleContext(0.0, 50, 8, PVFMM.StokesPressure)
+        pv_out = PVFMM.evaluate(ctx, src_flat, sl, nothing, trg_flat; setup=true)
+        ref = _direct_stokes_pressure_3d(sources, forces, targets)
+        _assert_close_up_to_scale(ref, pv_out[1:ntrg])
+    end
+end

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -1,0 +1,23 @@
+using Test
+using PVFMM
+
+@testset "PVFMM Julia interface parity" begin
+    @test isdefined(PVFMM, :FMMKernel)
+    @test isdefined(PVFMM, :FMMVolumeContext)
+    @test isdefined(PVFMM, :FMMParticleContext)
+    @test isdefined(PVFMM, :FMMVolumeTree)
+    @test isdefined(PVFMM, :nodes_to_coeff)
+
+    expected_exports = (
+        :FMMKernel,
+        :FMMVolumeContext,
+        :FMMParticleContext,
+        :FMMVolumeTree,
+        :nodes_to_coeff,
+    )
+    for name in expected_exports
+        @test name in names(PVFMM)
+    end
+end
+
+include("reference_comparison.jl")

--- a/src/pvfmm-wrapper.cpp
+++ b/src/pvfmm-wrapper.cpp
@@ -12,6 +12,15 @@ extern "C" { // Volume FM
 #define PVFMM_FULL_PERIODIC pvfmm::Periodic
 #endif
 
+static void PVFMMEnsureMPIInitialized() {
+  int initialized = 0;
+  MPI_Initialized(&initialized);
+  if (!initialized) {
+    int provided = 0;
+    MPI_Init_thread(nullptr, nullptr, MPI_THREAD_FUNNELED, &provided);
+  }
+}
+
 void* PVFMMCreateVolumeFMMF(int m, int q, enum PVFMMKernel kernel, MPI_Comm comm) {
   const pvfmm::Kernel<float>* ker = nullptr;
   if (kernel == PVFMMLaplacePotential   ) ker = &pvfmm::LaplaceKernel   <float>::potential();
@@ -880,6 +889,11 @@ void* PVFMMCreateContextF(float box_size, int n, int m, enum PVFMMKernel kernel,
   return PVFMMCreateContext<float>(box_size, n, m, PVFMM_MAX_DEPTH, ker, comm);
 }
 
+void* PVFMMCreateContextFWorld(float box_size, int n, int m, enum PVFMMKernel kernel) {
+  PVFMMEnsureMPIInitialized();
+  return PVFMMCreateContextF(box_size, n, m, kernel, MPI_COMM_WORLD);
+}
+
 void PVFMMEvalF(const float* src_pos, const float* sl_den, const float* dl_den, long n_src, const float* trg_pos, float* trg_val, long n_trg, const void* ctx, int setup) {
   PVFMMEval<float>(src_pos, sl_den, dl_den, n_src, trg_pos, trg_val, n_trg, ctx, setup);
 }
@@ -898,6 +912,11 @@ void* PVFMMCreateContextD(double box_size, int n, int m, enum PVFMMKernel kernel
   if (kernel == PVFMMStokesVelocityGrad ) ker = &pvfmm::StokesKernel    <double>::vel_grad();
   if (kernel == PVFMMBiotSavartPotential) ker = &pvfmm::BiotSavartKernel<double>::potential();
   return PVFMMCreateContext<double>(box_size, n, m, PVFMM_MAX_DEPTH, ker, comm);
+}
+
+void* PVFMMCreateContextDWorld(double box_size, int n, int m, enum PVFMMKernel kernel) {
+  PVFMMEnsureMPIInitialized();
+  return PVFMMCreateContextD(box_size, n, m, kernel, MPI_COMM_WORLD);
 }
 
 void PVFMMEvalD(const double* src_pos, const double* sl_den, const double* dl_den, long n_src, const double* trg_pos, double* trg_val, long n_trg, const void* ctx, int setup) {


### PR DESCRIPTION
## Summary
- add a new julia package with a high-level PVFMM interface (`FMMKernel`, contexts, tree helpers, and evaluate wrappers)
- extend the C wrapper API with world-context creation helpers for Julia (`PVFMMCreateContextDWorld` and `PVFMMCreateContextFWorld`)
- add Julia tests for interface parity and kernel validation against direct O(N^2) reference evaluation (no FMM2D/FMM3D dependency)
- document Julia bindings in top-level README and add a Julia README with API notes and an MWE