### PR TITLE
bugfix: Fix alignment bugs that appear when compiling with clang++

### DIFF
--- a/include/fmm_node.txx
+++ b/include/fmm_node.txx
@@ -142,17 +142,19 @@ void FMM_Node<Node>::Unpack(PackedData p0, bool own_data){
   char* data_ptr=(char*)p0.data;
 
   // Check header
-  assert(((size_t*)data_ptr)[0]==p0.length);
+  size_t data_ptr_len;
+  std::memcpy(&data_ptr_len, data_ptr, sizeof(size_t));
+  assert(data_ptr_len==p0.length);
   data_ptr+=sizeof(size_t);
 
   PackedData p2;
-  p2.length=(((size_t*)data_ptr)[0]); data_ptr+=sizeof(size_t);
+  std::memcpy(&p2.length, data_ptr, sizeof(size_t)); data_ptr+=sizeof(size_t);
   p2.data=(void*)data_ptr; data_ptr+=p2.length;
   InitMultipole(p2,own_data);
 
   PackedData p1;
   p1.data=data_ptr;
-  p1.length=((size_t*)data_ptr)[0];
+  std::memcpy(&p1.length, data_ptr, sizeof(size_t));
   Node::Unpack(p1, own_data);
 }
 

--- a/include/mpi_node.txx
+++ b/include/mpi_node.txx
@@ -300,46 +300,52 @@ PackedData MPI_Node<T>::Pack(bool ghost, void* buff_ptr, size_t offset){
   data_ptr+=offset;
 
   // Header
-  ((size_t*)data_ptr)[0]=p0.length;
+  std::memcpy(data_ptr, &p0.length, sizeof(size_t));
   data_ptr+=sizeof(size_t);
 
-  ((int*)data_ptr)[0]=this->Depth();
+  std::memcpy(data_ptr, &this->depth, sizeof(int));
   data_ptr+=sizeof(int);
 
-  ((long long*)data_ptr)[0]=this->NodeCost();
+  std::memcpy(data_ptr, &this->NodeCost(), sizeof(long long));
   data_ptr+=sizeof(long long);
 
-  ((MortonId*)data_ptr)[0]=this->GetMortonId();
+  MortonId mid = this->GetMortonId();
+  std::memcpy(data_ptr, &mid, sizeof(MortonId));
   data_ptr+=sizeof(MortonId);
 
   // Copy Vector data.
   for(size_t j=0;j<pt_coord.size();j++){
+    const size_t zero = 0;
     if(pt_coord[j]){
       Vector<Real_t>& vec=*pt_coord[j];
-      ((size_t*)data_ptr)[0]=vec.Dim(); data_ptr+=sizeof(size_t);
+      const size_t vec_dim = vec.Dim();
+      std::memcpy(data_ptr, &vec_dim, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(vec.Dim()>0 && data_ptr!=(char*)&vec[0])
         mem::copy<Real_t>((Real_t*)data_ptr, &vec[0], vec.Dim());
       data_ptr+=vec.Dim()*sizeof(Real_t);
     }else{
-      ((size_t*)data_ptr)[0]=0; data_ptr+=sizeof(size_t);
+      std::memcpy(data_ptr, &zero, sizeof(size_t)); data_ptr+=sizeof(size_t);
     }
     if(pt_value[j]){
       Vector<Real_t>& vec=*pt_value[j];
-      ((size_t*)data_ptr)[0]=vec.Dim(); data_ptr+=sizeof(size_t);
+      const size_t vec_dim = vec.Dim();
+      std::memcpy(data_ptr, &vec_dim, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(vec.Dim()>0 && data_ptr!=(char*)&vec[0])
         mem::copy<Real_t>((Real_t*)data_ptr, &vec[0], vec.Dim());
       data_ptr+=vec.Dim()*sizeof(Real_t);
     }else{
-      ((size_t*)data_ptr)[0]=0; data_ptr+=sizeof(size_t);
+      std::memcpy(data_ptr, &zero, sizeof(size_t)); data_ptr+=sizeof(size_t);
     }
     if(pt_scatter[j] && !ghost){
       Vector<size_t>& vec=*pt_scatter[j];
-      ((size_t*)data_ptr)[0]=vec.Dim(); data_ptr+=sizeof(size_t);
+      const size_t vec_dim = vec.Dim();
+      std::memcpy(data_ptr, &vec_dim, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(vec.Dim()>0 && data_ptr!=(char*)&vec[0])
         mem::copy<size_t>((size_t*)data_ptr, &vec[0], vec.Dim());
       data_ptr+=vec.Dim()*sizeof(size_t);
     }else{
-      ((size_t*)data_ptr)[0]=0; data_ptr+=sizeof(size_t);
+      std::memcpy(data_ptr, &zero, sizeof(size_t));
+      data_ptr += sizeof(size_t);
     }
   }
 
@@ -356,22 +362,27 @@ void MPI_Node<T>::Unpack(PackedData p0, bool own_data){
   char* data_ptr=(char*)p0.data;
 
   // Check header
-  assert(((size_t*)data_ptr)[0]==p0.length);
+  size_t data_ptr_len_check;
+  std::memcpy(&data_ptr_len_check, data_ptr, sizeof(size_t));
+  assert(data_ptr_len_check==p0.length);
   data_ptr+=sizeof(size_t);
 
-  this->depth=(((int*)data_ptr)[0]);
+  std::memcpy(&this->depth, data_ptr, sizeof(int));
   data_ptr+=sizeof(int);
 
-  this->NodeCost()=(((long long*)data_ptr)[0]);
+  std::memcpy(&this->NodeCost(), data_ptr, sizeof(long long));
   data_ptr+=sizeof(long long);
 
-  this->SetCoord(((MortonId*)data_ptr)[0]);
+  MortonId mid;
+  std::memcpy(&mid, data_ptr, sizeof(MortonId));
+  this->SetCoord(mid);
   data_ptr+=sizeof(MortonId);
 
   for(size_t j=0;j<pt_coord.size();j++){
     if(pt_coord[j]){
       Vector<Real_t>& vec=*pt_coord[j];
-      size_t vec_sz=(((size_t*)data_ptr)[0]); data_ptr+=sizeof(size_t);
+      size_t vec_sz;
+      std::memcpy(&vec_sz, data_ptr, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(own_data){
         vec=Vector<Real_t>(vec_sz,(Real_t*)data_ptr,false);
       }else{
@@ -384,7 +395,8 @@ void MPI_Node<T>::Unpack(PackedData p0, bool own_data){
     }
     if(pt_value[j]){
       Vector<Real_t>& vec=*pt_value[j];
-      size_t vec_sz=(((size_t*)data_ptr)[0]); data_ptr+=sizeof(size_t);
+      size_t vec_sz;
+      std::memcpy(&vec_sz, data_ptr, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(own_data){
         vec=Vector<Real_t>(vec_sz,(Real_t*)data_ptr,false);
       }else{
@@ -397,7 +409,8 @@ void MPI_Node<T>::Unpack(PackedData p0, bool own_data){
     }
     if(pt_scatter[j]){
       Vector<size_t>& vec=*pt_scatter[j];
-      size_t vec_sz=(((size_t*)data_ptr)[0]); data_ptr+=sizeof(size_t);
+      size_t vec_sz;
+      std::memcpy(&vec_sz, data_ptr, sizeof(size_t)); data_ptr+=sizeof(size_t);
       if(own_data){
         vec=Vector<size_t>(vec_sz,(size_t*)data_ptr,false);
       }else{

--- a/include/mpi_tree.txx
+++ b/include/mpi_tree.txx
@@ -577,10 +577,10 @@ void MPI_Tree<TreeNode>::RedistNodes(MortonId* loc_min) {
   char* recv_buff=mem::aligned_new<char>(rbuff_size);
   std::vector<char*> data_ptr(leaf_cnt);
   char* s_ptr=send_buff;
-  for(size_t i=0;i<leaf_cnt;i++){
-    *((MortonId*)s_ptr)=in  [i]       ; s_ptr+=sizeof(MortonId);
-    *((  size_t*)s_ptr)=data[i].length; s_ptr+=sizeof(size_t);
-    data_ptr[i]=s_ptr                 ; s_ptr+=data[i].length;
+  for(size_t i = 0; i < leaf_cnt; i++) {
+    std::memcpy(s_ptr, &in[i], sizeof(MortonId))       ; s_ptr += sizeof(MortonId);
+    std::memcpy(s_ptr, &data[i].length, sizeof(size_t)); s_ptr += sizeof(size_t);
+    data_ptr[i] = s_ptr                                ; s_ptr += data[i].length;
   }
   #pragma omp parallel for
   for(int p=0;p<omp_p;p++){
@@ -596,9 +596,9 @@ void MPI_Tree<TreeNode>::RedistNodes(MortonId* loc_min) {
   char* r_ptr=recv_buff;
   std::vector<PackedData> r_data(recv_cnt);
   for(size_t i=0;i<recv_cnt;i++){
-    out   [i]       =*(MortonId*)r_ptr; r_ptr+=sizeof(MortonId);
-    r_data[i].length=*(  size_t*)r_ptr; r_ptr+=sizeof(size_t);
-    r_data[i].data  =            r_ptr; r_ptr+=r_data[i].length;
+    std::memcpy(&out   [i],        r_ptr, sizeof(MortonId)); r_ptr+=sizeof(MortonId);
+    std::memcpy(&r_data[i].length, r_ptr, sizeof(size_t))  ; r_ptr+=sizeof(size_t);
+    r_data[i].data = r_ptr                                 ; r_ptr+=r_data[i].length;
   }
 
   //Initialize all new nodes.
@@ -1791,8 +1791,8 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
   { // Unpack received octants.
     std::vector<par::SortPair<MortonId,size_t> > mid_indx_pair;
     for(size_t i=0; i<recv_length;){
-      CommData& comm_data=*(CommData*)&recv_buff[i];
-      recv_data.push_back(&comm_data);
+      recv_data.push_back(&recv_buff[i]);
+      CommData comm_data = *(CommData*)&recv_buff[i];
       { // Add mid_indx_pair
         par::SortPair<MortonId,size_t> p;
         p.key=comm_data.mid;
@@ -1869,7 +1869,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
     for(size_t i=0;i<recv_data.size();i++){ // Unpack
       if(!recv_nodes[i]->IsGhost()) continue;
       assert(recv_nodes[i]->IsGhost());
-      CommData& comm_data=*(CommData*)recv_data[i];
+      CommData comm_data=*(CommData*)recv_data[i];
 
       PackedData p;
       p.data=((char*)recv_data[i])+sizeof(CommData);
@@ -1911,14 +1911,14 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
         if(shrd_data.size()==0 || shrd_data.back()!=&comm_data) this->memgr.free(&comm_data);
       }
       for(size_t i=0;i<recv_data.size();i++){
-        CommData& comm_data=*(CommData*)recv_data[i];
+        CommData comm_data=*(CommData*)recv_data[i];
         assert(comm_data.mid.GetDepth()>0);
         size_t d=comm_data.mid.GetDepth()-1;
         if(d<shrd_mid.size() && shrd_mid[d].getDFD()>=mins[rank])
         for(size_t j=0;j<comm_data.usr_cnt;j++){
           if(comm_data.usr_mid[j]==shrd_mid[d]){
             char* data_ptr=(char*)this->memgr.malloc(comm_data.pkd_length);
-            mem::copy<char>(data_ptr, (char*)&comm_data, comm_data.pkd_length);
+            mem::copy<char>(data_ptr, (char*)recv_data[i], comm_data.pkd_length);
             shrd_data.push_back(data_ptr);
             break;
           }
@@ -1951,7 +1951,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
           send_size.push_back(comm_data.pkd_length);
         }
         std::vector<size_t> send_disp(send_data.size(),0);
-        omp_par::scan(&send_size[0],&send_disp[0],send_data.size());
+        if(send_data.size()) omp_par::scan(&send_size[0],&send_disp[0],send_data.size());
         if(send_data.size()>0) send_length=send_size.back()+send_disp.back();
 
         // Resize send_buff.
@@ -1989,8 +1989,8 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
       { // Unpack received octants.
         std::vector<par::SortPair<MortonId,size_t> > mid_indx_pair;
         for(size_t i=0; i<(size_t)recv_length;){
-          CommData& comm_data=*(CommData*)&recv_buff[i];
-          recv_data.push_back(&comm_data);
+          recv_data.push_back(&recv_buff[i]);
+          CommData comm_data=*(CommData*)&recv_buff[i];
           { // Add mid_indx_pair
             par::SortPair<MortonId,size_t> p;
             p.key=comm_data.mid;
@@ -2024,7 +2024,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
 //          recv_nodes[i]=srch_node;
 //        }
         { // Find received octants in tree.
-          omp_par::merge_sort(&mid_indx_pair[0], &mid_indx_pair[0]+mid_indx_pair.size());
+          if (mid_indx_pair.size()) omp_par::merge_sort(&mid_indx_pair[0], &mid_indx_pair[0]+mid_indx_pair.size());
           std::vector<size_t> indx(omp_p+1);
           for(int i=0;i<=omp_p;i++){
             size_t j=(mid_indx_pair.size()*i)/omp_p;
@@ -2088,7 +2088,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
         for(size_t i=0;i<recv_data.size();i++){
           if(!recv_nodes[i]->IsGhost()) continue;
           assert(recv_nodes[i]->IsGhost());
-          CommData& comm_data=*(CommData*)recv_data[i];
+          CommData comm_data=*(CommData*)recv_data[i];
 
           PackedData p;
           p.data=((char*)recv_data[i])+sizeof(CommData);
@@ -2101,7 +2101,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
       send_pid=(rank+pid_shift<num_p?rank+pid_shift:rank);
       if(send_pid!=rank){ // Set shrd_data
         for(size_t i=0;i<recv_data.size();i++){
-          CommData& comm_data=*(CommData*)recv_data[i];
+          CommData comm_data=*(CommData*)recv_data[i];
 
           //{ // Skip if this node already exists.
           //  bool skip=false;
@@ -2122,7 +2122,7 @@ void MPI_Tree<TreeNode>::ConstructLET_Sparse(BoundaryType bndry){
           for(size_t j=0;j<comm_data.usr_cnt;j++){
             if(comm_data.usr_mid[j]==shrd_mid[d]){
               char* data_ptr=(char*)this->memgr.malloc(comm_data.pkd_length);
-              mem::copy<char>(data_ptr, (char*)&comm_data, comm_data.pkd_length);
+              mem::copy<char>(data_ptr, (char*)recv_data[i], comm_data.pkd_length);
               shrd_data.push_back(data_ptr);
               break;
             }

--- a/include/parUtils.txx
+++ b/include/parUtils.txx
@@ -211,9 +211,9 @@ namespace par{
             char* sbuff_new=mem::aligned_new<char>(sdisp_new[new_np-1]+s_cnt_new[new_np-1]);
             #pragma omp parallel for
             for(int i=0;i<new_np;i++){
-              memcpy(&sbuff_new[sdisp_new[i]                      ],&sbuff   [sdisp_old[i]],s_cnt_old[i]);
-              memcpy(&sbuff_new[sdisp_new[i]+s_cnt_old[i]         ],&rbuff   [rdisp    [i]],r_cnt    [i]);
-              memcpy(&sbuff_new[sdisp_new[i]+s_cnt_old[i]+r_cnt[i]],&rbuffext[rdisp_ext[i]],r_cnt_ext[i]);
+              if (s_cnt_old[i]) memcpy(&sbuff_new[sdisp_new[i]                      ],&sbuff   [sdisp_old[i]],s_cnt_old[i]);
+              if (r_cnt[i])     memcpy(&sbuff_new[sdisp_new[i]+s_cnt_old[i]         ],&rbuff   [rdisp    [i]],r_cnt    [i]);
+              if (r_cnt_ext[i]) memcpy(&sbuff_new[sdisp_new[i]+s_cnt_old[i]+r_cnt[i]],&rbuffext[rdisp_ext[i]],r_cnt_ext[i]);
             }
 
             //Free memory.
@@ -471,15 +471,17 @@ namespace par{
           // Exchange data.
           rbuff    .Resize(    rsize/sizeof(T));
           rbuff_ext.Resize(ext_rsize/sizeof(T));
-          MPI_Sendrecv                  (sbuff,ssize,MPI_BYTE, partner,0,   &rbuff    [0],    rsize,MPI_BYTE, partner,   0,comm,&status);
-          if(extra_partner) MPI_Sendrecv( NULL,    0,MPI_BYTE,split_id,0,   &rbuff_ext[0],ext_rsize,MPI_BYTE,split_id,   0,comm,&status);
+          T *rbuff_ptr = rsize ? &rbuff[0] : nullptr;
+          T *rbuff_ext_ptr = ext_rsize ? &rbuff_ext[0] : nullptr;
+          MPI_Sendrecv                  (sbuff,ssize,MPI_BYTE, partner,0,   rbuff_ptr    ,    rsize,MPI_BYTE, partner,   0,comm,&status);
+          if(extra_partner) MPI_Sendrecv( NULL,    0,MPI_BYTE,split_id,0,   rbuff_ext_ptr,ext_rsize,MPI_BYTE,split_id,   0,comm,&status);
 
           int nbuff_size=lsize+rsize+ext_rsize;
           nbuff.Resize(nbuff_size/sizeof(T));
-          omp_par::merge<T*>((T*)lbuff, (T*)(lbuff+lsize), &rbuff[0], &rbuff[0]+(rsize/sizeof(T)), &nbuff[0], omp_p, std::less<T>());
+          omp_par::merge<T*>((T*)lbuff, (T*)(lbuff+lsize), rbuff_ptr, rbuff_ptr+(rsize/sizeof(T)), &nbuff[0], omp_p, std::less<T>());
           if(ext_rsize>0 && nbuff.Dim()>0){
             nbuff_ext.Resize(nbuff_size/sizeof(T));
-            omp_par::merge<T*>(&nbuff[0], &nbuff[0]+((lsize+rsize)/sizeof(T)), &rbuff_ext[0], &rbuff_ext[0]+(ext_rsize/sizeof(T)), &nbuff_ext[0], omp_p, std::less<T>());
+            omp_par::merge<T*>(&nbuff[0], &nbuff[0]+((lsize+rsize)/sizeof(T)), rbuff_ext_ptr, rbuff_ext_ptr+(ext_rsize/sizeof(T)), &nbuff_ext[0], omp_p, std::less<T>());
             nbuff.Swap(nbuff_ext);
             nbuff_ext.Resize(0);
           }


### PR DESCRIPTION
When compiling with clang++ across any version I checked (18, 19, 21), there are issues as soon as multiple MPI ranks are involved and optimizations are enabled. The main culprits are `void MPI_Tree<TreeNode>::ConstructLET_Sparse()` and `void MPI_Tree<TreeNode>::RedistNodes()`. These bugs were annoying to track down. This is one of the worst heisenbugs I've ever encountered, and it's fortunate that modern sanitizers (and LLMs) are so powerful.

1. bug only being around with optimizations enabled
2. only on clang (compiler bug? -- no)
3. crashing in seemingly unreachable codepaths (`if` conditional false, and crashing on first line after conditional)
4. address sanitizer running with no issues (and completely fixing the bug)

I have a new love for the undefined behavior sanitizer (-fsanitize=undefined), which unearthed the issue immediately. Notably, the way the data is demarshalled from the `char` arrays used to transmit buffers between MPI ranks. The header (CommData) is transmitted with a data payload. In many locations, the resulting receive buffers are cast from a char* to a CommData reference, which is illegal due to alignment of the underlying elements being off. Usually this is fine and just works as you might expect, though can be suboptimal due to the compiler having to issue multiple loads and shifts to reconstruct from the illegal loads. Sometimes the compiler makes assumptions that it's actually aligned when it isn't, and doesn't issue the proper instructions to handle the unaligned data, resulting in some seriously undefined behavior.

So. That's what was happening. There are two fixes that I used to mitigate this.
1. If there are only reads of the data, and the data is temporary, you can just dereference the pointer and copy it to a local stack variable which will then be properly aligned
2. Reads/writes can alternatively be done of member variables by doing a memcpy to the expected address

After fixing these issues, other issues popped up with undefined behavior
1. Adding offsets to null pointers
2. Binding references to nullptrs

These all came up in the context of getting the data pointer of a vector `&vector[0]`, so I just made some `.size()` or `.Dim()` checks to guard against it. Now `-fsanitize=undefined` is reporting no errors on any of the test runs I ran.

Reproducing the bug at FI:
```
module load gcc llvm openmpi fftw openblas flexiblas cmake
cmake .. -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS="-march=native"
make -j
mpirun -np 3 ./examples/example1 -N 10000
```