### PR TITLE
CompactData: align the emitted offsets, not the stale size total

### DIFF
--- a/include/precomp_mat.txx
+++ b/include/precomp_mat.txx
@@ -155,20 +155,20 @@ size_t PrecompMat<T>::CompactData(int level, Mat_Type type, Matrix<char>& comp_d
     for(size_t j=0;j<mat_cnt;j++){
       Matrix     <T>& M =Mat   (level,type,j);
       offset_indx[j][0]=data_offset; indx_ptr+=sizeof(size_t);
-      data_offset+=M.Dim(0)*M.Dim(1)*sizeof(T); mem_size=mem::align_ptr(mem_size);
+      data_offset+=M.Dim(0)*M.Dim(1)*sizeof(T); data_offset=mem::align_ptr(data_offset);
 
       for(size_t l=l0;l<l1;l++){
         Permutation<T>& Pr=Perm_R(l,type,j);
         offset_indx[j][1+4*(l-l0)+0]=data_offset;
-        data_offset+=Pr.Dim()*sizeof(PVFMM_PERM_INT_T); mem_size=mem::align_ptr(mem_size);
+        data_offset+=Pr.Dim()*sizeof(PVFMM_PERM_INT_T); data_offset=mem::align_ptr(data_offset);
         offset_indx[j][1+4*(l-l0)+1]=data_offset;
-        data_offset+=Pr.Dim()*sizeof(T);          mem_size=mem::align_ptr(mem_size);
+        data_offset+=Pr.Dim()*sizeof(T);          data_offset=mem::align_ptr(data_offset);
 
         Permutation<T>& Pc=Perm_C(l,type,j);
         offset_indx[j][1+4*(l-l0)+2]=data_offset;
-        data_offset+=Pc.Dim()*sizeof(PVFMM_PERM_INT_T); mem_size=mem::align_ptr(mem_size);
+        data_offset+=Pc.Dim()*sizeof(PVFMM_PERM_INT_T); data_offset=mem::align_ptr(data_offset);
         offset_indx[j][1+4*(l-l0)+3]=data_offset;
-        data_offset+=Pc.Dim()*sizeof(T);          mem_size=mem::align_ptr(mem_size);
+        data_offset+=Pc.Dim()*sizeof(T);          data_offset=mem::align_ptr(data_offset);
       }
     }
   }


### PR DESCRIPTION
The offset-emitting loop in PrecompMat::CompactData advanced data_offset past each segment and then aligned mem_size -- a dead value left over from the sizing pass -- so the offsets recorded in offset_indx packed the matrix/perm/scal segments back-to-back unaligned, while the buffer was sized for the aligned layout. Align data_offset instead, matching the sizing pass.

For double every segment is a multiple of 8 bytes so the offsets were accidentally aligned. For float, odd-length matrix and scal segments (n*4 bytes) put subsequent perm offsets at 4 (mod 8); the host reads them fine (x86 tolerates unaligned loads) but the GPU permutation kernels do '(size_t*)(precomp_data+offset)' 8-byte loads and fault with 'misaligned address'. This crashed fmm_cheb with float + CUDA for laplace/stokes kernels (helmholtz escaped because ker_dim=[2,2] makes all segment lengths even).

In-memory layout only; the Save2File cache format is unaffected.