### PR TITLE
ci-debug: open SSH (tmate) into runner on failure [debug branch]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,10 @@ jobs:
 
     # CI-DEBUG ONLY: on failure, open an SSH (tmate) session into the runner so the
     # failing macOS build can be inspected live. Restricted to the workflow actor.
-    - name: Debug via SSH (tmate) on failure
-      if: ${{ failure() && runner.os == 'macOS' }}
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
+    # Uncomment to re-enable live debugging.
+    #- name: Debug via SSH (tmate) on failure
+    #  if: ${{ failure() && runner.os == 'macOS' }}
+    #  uses: mxschmitt/action-tmate@v3
+    #  with:
+    #    limit-access-to-actor: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         - os: ubuntu-latest
           compiler: clang++
         - os: macOS-latest
-          compiler: g++-14
+          compiler: g++-15
     runs-on: ${{ matrix.os }}
     env:
       OMPI_CXX: ${{ matrix.compiler }}
@@ -34,7 +34,7 @@ jobs:
     - name: Setup macOS
       if: runner.os == 'macOS'
       run: |
-          brew install open-mpi openblas fftw autoconf automake libtool
+          brew install gcc@15 open-mpi openblas fftw autoconf automake libtool
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun --show-sdk-version)" >> "$GITHUB_ENV"
 
     - name: Setup Linux
@@ -48,7 +48,7 @@ jobs:
 
     - name: Configure macOS
       if: runner.os == 'macOS'
-      run: ./configure F77="gfortran-14" --with-openmp-flag="fopenmp" --with-fftw=$(brew --prefix fftw) --with-blas="-L$(brew --prefix openblas)/lib -lopenblas" --with-lapack="-L$(brew --prefix openblas)/lib -lopenblas"
+      run: ./configure F77="gfortran-15" --with-openmp-flag="fopenmp" --with-fftw=$(brew --prefix fftw) --with-blas="-L$(brew --prefix openblas)/lib -lopenblas" --with-lapack="-L$(brew --prefix openblas)/lib -lopenblas"
 
     - name: Configure Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ develop, ci-debug ]
+    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
 
     - name: Setup macOS
       if: runner.os == 'macOS'
-      run: brew install open-mpi openblas fftw autoconf automake libtool
+      run: |
+          brew install open-mpi openblas fftw autoconf automake libtool
+          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun --show-sdk-version)" >> "$GITHUB_ENV"
 
     - name: Setup Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         - os: ubuntu-latest
           compiler: clang++
         - os: macOS-latest
-          compiler: g++-15
+          compiler: g++   # resolved to the newest installed gcc in "Setup macOS"
     runs-on: ${{ matrix.os }}
     env:
       OMPI_CXX: ${{ matrix.compiler }}
@@ -34,8 +34,13 @@ jobs:
     - name: Setup macOS
       if: runner.os == 'macOS'
       run: |
-          brew install gcc@15 open-mpi openblas fftw autoconf automake libtool
+          brew install gcc open-mpi openblas fftw autoconf automake libtool
+          # Use the newest Homebrew gcc (older g++ can't parse the current macOS SDK headers).
+          GCC_MAJOR=$(brew list --versions gcc | tail -1 | awk '{print $NF}' | cut -d. -f1)
+          echo "OMPI_CXX=g++-${GCC_MAJOR}" >> "$GITHUB_ENV"
+          echo "PVFMM_F77=gfortran-${GCC_MAJOR}" >> "$GITHUB_ENV"
           echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun --show-sdk-version)" >> "$GITHUB_ENV"
+          echo "macOS toolchain: g++-${GCC_MAJOR} / gfortran-${GCC_MAJOR}"
 
     - name: Setup Linux
       if: runner.os == 'Linux'
@@ -48,7 +53,7 @@ jobs:
 
     - name: Configure macOS
       if: runner.os == 'macOS'
-      run: ./configure F77="gfortran-15" --with-openmp-flag="fopenmp" --with-fftw=$(brew --prefix fftw) --with-blas="-L$(brew --prefix openblas)/lib -lopenblas" --with-lapack="-L$(brew --prefix openblas)/lib -lopenblas"
+      run: ./configure F77="${PVFMM_F77}" --with-openmp-flag="fopenmp" --with-fftw=$(brew --prefix fftw) --with-blas="-L$(brew --prefix openblas)/lib -lopenblas" --with-lapack="-L$(brew --prefix openblas)/lib -lopenblas"
 
     - name: Configure Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, ci-debug ]
   pull_request:
     branches: [ develop ]
 
@@ -54,4 +54,12 @@ jobs:
 
     - name: Build
       run: make all-examples -j
+
+    # CI-DEBUG ONLY: on failure, open an SSH (tmate) session into the runner so the
+    # failing macOS build can be inspected live. Restricted to the workflow actor.
+    - name: Debug via SSH (tmate) on failure
+      if: ${{ failure() && runner.os == 'macOS' }}
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
 

--- a/include/fmm_pts.txx
+++ b/include/fmm_pts.txx
@@ -19,12 +19,12 @@
 
 #if defined(__ARM_NEON)
 #  include "sctl/sse2neon.h"
-#  define __SSE__
-#  define __SSE2__
-#  define __SSE3__
-#  define __SSE4__
-#  define __SSE4_1__
-#  define __SSE4_2__
+#  define __SSE__ 1
+#  define __SSE2__ 1
+#  define __SSE3__ 1
+#  define __SSE4__ 1
+#  define __SSE4_1__ 1
+#  define __SSE4_2__ 1
 #  define _MM_SHUFFLE2(fp1, fp0) (((fp1) << 1) | (fp0))
 #elif defined(__MMX__) || defined(__SSE__) || defined(__SSE2__) || defined(__SSE4_2__) || defined(__AVX__) || defined(__AVX512F__)
 #  ifdef _MSC_VER


### PR DESCRIPTION
Add ci-debug to the push triggers and an action-tmate step that runs on macOS build failure, so the failing macOS-26/g++-14 configure step can be inspected live on the runner. Access is limited to the workflow actor.

This branch is for CI debugging only and should not be merged.