### PR TITLE
Make FMM_Pts::Initialize re-entrant; require both vol_poten for periodic BC

### DIFF
--- a/include/fmm_cheb.txx
+++ b/include/fmm_cheb.txx
@@ -80,6 +80,7 @@ void FMM_Cheb<FMMNode>::Initialize(int mult_order, int cheb_deg_, const sctl::Co
 
   int dim=3; //Only supporting 3D
   cheb_deg=cheb_deg_;
+  this->mat_fname.clear(); // else a second Initialize() reuses the file for the previous cheb_deg/mult_order
   if(this->mat_fname.size()==0){
     std::stringstream st;
     st<<PVFMM_PRECOMP_DATA_PATH;
@@ -1068,7 +1069,7 @@ void FMM_Cheb<FMMNode>::Down2Target     (SetupData<FMMNode_t>& setup_data, bool 
 template <class FMMNode>
 void FMM_Cheb<FMMNode>::PostProcessing(FMMTree_t* tree, std::vector<FMMNode_t*>& nodes, BoundaryType bndry){
 #ifndef PVFMM_EXTENDED_BC
-  if(this->kernel->k_m2l->vol_poten && bndry==Periodic && PVFMM_BC_LEVELS>0){ // Add analytical near-field to target potential
+  if(this->kernel->k_m2l->vol_poten && this->kernel->k_m2t->vol_poten && bndry==Periodic && PVFMM_BC_LEVELS>0){ // Add analytical near-field to target potential
     const Kernel<Real_t>& k_m2t=*this->kernel->k_m2t;
     int ker_dim[2]={k_m2t.ker_dim[0],k_m2t.ker_dim[1]};
 

--- a/include/fmm_pts.hpp
+++ b/include/fmm_pts.hpp
@@ -124,7 +124,7 @@ class FMM_Pts{
    * \brief Constructor.
    */
   FMM_Pts(): vprecomp_fft_flag(false), vlist_fft_flag(false), vlist_ifft_flag(false),
-             kernel(NULL), mat(NULL), m2c(NULL){};
+             kernel(NULL), mat(NULL), mat_fname_auto(false), m2c(NULL){};
 
   /**
    * \brief Virtual destructor.
@@ -259,6 +259,7 @@ class FMM_Pts{
   const Kernel<Real_t>* kernel;    //The kernel function.
   PrecompMat<Real_t>* mat;   //Handles storage of matrices.
   std::string mat_fname;
+  bool mat_fname_auto;       // mat_fname was derived from multipole_order here, not set by a derived class
   int multipole_order;       //Order of multipole expansion.
   sctl::Comm sctl_comm;
   Real_t* m2c;

--- a/include/fmm_pts.txx
+++ b/include/fmm_pts.txx
@@ -233,6 +233,16 @@ void FMM_Pts<FMMNode>::Initialize(int mult_order, const sctl::Comm& comm_, const
   kernel=kernel_;
   assert(kernel!=NULL);
 
+  { // Discard data cached for a previous multipole_order, so that Initialize()
+    // can be called again on the same object.
+    if(mat_fname_auto) mat_fname.clear(); // else the old order's precomputed file is reloaded
+    vprecomp_fft_flag=false;    // else the FFT plans keep the old transform size
+    vlist_fft_flag   =false;
+    vlist_ifft_flag  =false;
+    vlist_fft_map .ReInit(0);
+    vlist_ifft_map.ReInit(0);
+  }
+
   bool save_precomp=false;
   if (mat)  delete mat;
   mat=new PrecompMat<Real_t>(ScaleInvar());
@@ -262,6 +272,7 @@ void FMM_Pts<FMMNode>::Initialize(int mult_order, const sctl::Comm& comm_, const
     else st<<"_t"<<sizeof(Real_t);
     st<<".data";
     this->mat_fname=st.str();
+    this->mat_fname_auto=true;
     save_precomp=true;
   }
   this->mat->LoadFile(mat_fname.c_str(), this->sctl_comm);
@@ -990,7 +1001,7 @@ sctl::Matrix<typename FMMNode::Real_t>& FMM_Pts<FMMNode>::Precomp(int level, Mat
           sctl::Matrix<Real_t> M = M2L;
           for (int level = 1; level < PVFMM_BC_LEVELS; level++) M = M2L + M2M * (Pr * M * Pc) * L2L;
 
-          if (mat_indx == BoundaryType::PXYZ && kernel->k_m2l->vol_poten) { // Correction for far-field of analytical volume potential
+          if (mat_indx == BoundaryType::PXYZ && kernel->k_m2l->vol_poten && kernel->k_m2t->vol_poten) { // Correction for far-field of analytical volume potential
             int ker_dim[2] = {kernel->k_m2l->ker_dim[0], kernel->k_m2l->ker_dim[1]};
             sctl::Matrix<Real_t> M_far;
             { // Compute M_far
@@ -1080,7 +1091,7 @@ sctl::Matrix<typename FMMNode::Real_t>& FMM_Pts<FMMNode>::Precomp(int level, Mat
                       corner_vals[i][k*ker_dim[1]+j] += M_e2pt[i][j];
                 }
               }
-              if (mat_indx == BoundaryType::PXYZ && kernel->k_m2l->vol_poten) { // Subtract analytical vol_poten at corners
+              if (mat_indx == BoundaryType::PXYZ && kernel->k_m2l->vol_poten && kernel->k_m2t->vol_poten) { // Subtract analytical vol_poten at corners
                 sctl::Matrix<Real_t> M_analytic(ker_dim[0], n_corner*ker_dim[1]); M_analytic.SetZero();
                 kernel->k_m2l->vol_poten(&corner_pts[0], n_corner, &M_analytic[0][0]);
                 for (size_t j = 0; j < n_surf; j++)
@@ -5908,7 +5919,8 @@ void FMM_Pts<FMMNode>::Down2Target(SetupData<FMMNode_t>&  setup_data, bool devic
 template <class FMMNode>
 void FMM_Pts<FMMNode>::PostProcessing(FMMTree_t* tree, std::vector<FMMNode_t*>& nodes, BoundaryType bndry){
 #ifndef PVFMM_EXTENDED_BC
-  if(kernel->k_m2l->vol_poten && bndry==PXYZ && PVFMM_BC_LEVELS>0){ // Add analytical near-field to target potential
+  // The correction is built from k_m2l and evaluated with k_m2t, so both are needed.
+  if(kernel->k_m2l->vol_poten && kernel->k_m2t->vol_poten && bndry==PXYZ && PVFMM_BC_LEVELS>0){ // Add analytical near-field to target potential
     // TODO: Unclear what should be done for PX, PXY boundary conditions
     const Kernel<Real_t>& k_m2t=*kernel->k_m2t;
     int ker_dim[2]={k_m2t.ker_dim[0],k_m2t.ker_dim[1]};

--- a/include/interac_list.txx
+++ b/include/interac_list.txx
@@ -395,8 +395,10 @@ void InteracList<Node_t>::InitList(int max_r, int min_r, int step, Mat_Type t){
   }
   assert(count_==count);
 
-  interac_class[t].resize(count);
-  perm_list[t].resize(count);
+  // Clear before resizing: Initialize() may be called more than once, and
+  // perm_list entries are appended to below.
+  interac_class[t].clear(); interac_class[t].resize(count);
+  perm_list[t].clear();     perm_list[t].resize(count);
   if(!use_symmetries){ // Set interac_class=self
     for(size_t j=0;j<count;j++){
       int c_hash = coord_hash(&M[j][0]);


### PR DESCRIPTION

Calling Initialize() a second time on the same FMM_Pts/FMM_Cheb object either aborted or silently returned wrong results.  Three causes:

- InteracList::InitList resized interac_class/perm_list without clearing them, and the loop below appends, so each Initialize() doubled the symmetry list: PermutList(U2U,0) went [ReflecX,ReflecY,ReflecZ] -> [ReflecX,ReflecY,ReflecZ, ReflecX,ReflecY,ReflecZ].  Each reflection applied twice is the identity, so Perm_R degenerated to the identity and the far field was wrong, alternating correct/incorrect with the number of Initialize() calls.

- mat_fname was only built when empty, so a second Initialize() with a different multipole order reloaded the previous order's precomputed file and tripped `Permutation::operator*: P.Dim() == size`.  FMM_Cheb had the same problem with its own cheb_deg/mult_order filename.  mat_fname_auto keeps the reset from discarding a name set by a derived class.

- The FFT plans and reorder maps (vprecomp_fft_flag, vlist_fft_flag, vlist_ifft_flag, vlist_fft_map, vlist_ifft_map) were reset only in the destructor, so a changed multipole order kept the old transform size and hit `FFT: Wrong input size`.

This is reachable from sctl::ParticleFMM::SetAccuracy(), which marks the kernels for re-setup and re-Initializes the existing context.

Separately, the periodic volume-potential correction is built from k_m2l (Precomp BC_Type) but evaluated with k_m2t (PostProcessing).  These need not be the same Kernel object -- LaplaceKernel::gradient() and sctl's ParticleFMM both supply distinct ones -- so setting vol_poten on only one threw std::bad_function_call or half-applied the correction.  Require both; with either missing the correction is skipped, which is what the previous unconfigured behaviour did and is exact for a zero-mean source density.