### PR TITLE
Derive octree depth limit from sctl::MAX_DEPTH; bump SCTL

### DIFF
--- a/examples/src/fmm_cheb.cpp
+++ b/examples/src/fmm_cheb.cpp
@@ -357,8 +357,8 @@ void fmm_test(int test_case, size_t N, size_t M, bool unif, int mult_order, int 
   tree->InitFMM_Tree(false,bndry);
 
   { //Output max tree depth.
-    std::vector<size_t> all_nodes(PVFMM_MAX_DEPTH+1,0);
-    std::vector<size_t> leaf_nodes(PVFMM_MAX_DEPTH+1,0);
+    std::vector<size_t> all_nodes(sctl::MAX_DEPTH+1,0);
+    std::vector<size_t> leaf_nodes(sctl::MAX_DEPTH+1,0);
     std::vector<sctl::Iterator<FMMNode_t>>& nodes=tree->GetNodeList();
     for(size_t i=0;i<nodes.size();i++){
       sctl::Iterator<FMMNode_t> n=nodes[i];
@@ -367,7 +367,7 @@ void fmm_test(int test_case, size_t N, size_t M, bool unif, int mult_order, int 
     }
 
     if(!myrank) std::cout<<"All  Nodes: ";
-    for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+    for(int i=0;i<sctl::MAX_DEPTH;i++){
       int local_size=all_nodes[i];
       int global_size;
       comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size, 1), sctl::Ptr2Itr<int>(&global_size, 1), 1, sctl::CommOp::SUM);
@@ -376,7 +376,7 @@ void fmm_test(int test_case, size_t N, size_t M, bool unif, int mult_order, int 
     if(!myrank) std::cout<<'\n';
 
     if(!myrank) std::cout<<"Leaf Nodes: ";
-    for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+    for(int i=0;i<sctl::MAX_DEPTH;i++){
       int local_size=leaf_nodes[i];
       int global_size;
       comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size, 1), sctl::Ptr2Itr<int>(&global_size, 1), 1, sctl::CommOp::SUM);

--- a/examples/src/fmm_pts.cpp
+++ b/examples/src/fmm_pts.cpp
@@ -142,8 +142,8 @@ void fmm_test(int ker, size_t N, size_t M, Real_t b, int dist, int mult_order, i
 
   { //Output max tree depth.
     long nleaf=0, maxdepth=0;
-    std::vector<size_t> all_nodes(PVFMM_MAX_DEPTH+1,0);
-    std::vector<size_t> leaf_nodes(PVFMM_MAX_DEPTH+1,0);
+    std::vector<size_t> all_nodes(sctl::MAX_DEPTH+1,0);
+    std::vector<size_t> leaf_nodes(sctl::MAX_DEPTH+1,0);
     std::vector<sctl::Iterator<FMMNode_t>>& nodes=tree.GetNodeList();
     for(size_t i=0;i<nodes.size();i++){
       sctl::Iterator<FMMNode_t> n=nodes[i];
@@ -156,7 +156,7 @@ void fmm_test(int ker, size_t N, size_t M, Real_t b, int dist, int mult_order, i
     }
 
     if(!myrank) std::cout<<"All  Nodes: ";
-    for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+    for(int i=0;i<sctl::MAX_DEPTH;i++){
       int local_size=all_nodes[i];
       int global_size;
       comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size, 1), sctl::Ptr2Itr<int>(&global_size, 1), 1, sctl::CommOp::SUM);
@@ -165,7 +165,7 @@ void fmm_test(int ker, size_t N, size_t M, Real_t b, int dist, int mult_order, i
     if(!myrank) std::cout<<'\n';
 
     if(!myrank) std::cout<<"Leaf Nodes: ";
-    for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+    for(int i=0;i<sctl::MAX_DEPTH;i++){
       int local_size=leaf_nodes[i];
       int global_size;
       comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size, 1), sctl::Ptr2Itr<int>(&global_size, 1), 1, sctl::CommOp::SUM);

--- a/include/fmm_cheb.txx
+++ b/include/fmm_cheb.txx
@@ -30,37 +30,37 @@ FMM_Cheb<FMMNode>::~FMM_Cheb() {
       if(f==NULL) { //File does not exists.
         { // Delete easy to compute matrices.
           Mat_Type type=W_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
           }
           type=V_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
           }
           type=V1_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
           }
           type=U2U_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
           }
           type=D2D_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
           }
           type=D2T_Type;
-          for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+          for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
           for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
             sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
             M.ReInit(0,0);
@@ -155,37 +155,37 @@ void FMM_Cheb<FMMNode>::Initialize(int mult_order, int cheb_deg_, const sctl::Co
     if(f==NULL) { //File does not exists.
       { // Delete easy to compute matrices.
         Mat_Type type=W_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);
         }
         type=V_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);
         }
         type=V1_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);
         }
         type=U2U_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);
         }
         type=D2D_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);
         }
         type=D2T_Type;
-        for(int l=-PVFMM_BC_LEVELS;l<PVFMM_MAX_DEPTH;l++)
+        for(int l=-PVFMM_BC_LEVELS;l<sctl::MAX_DEPTH;l++)
         for(size_t indx=0;indx<this->interac_list.ListCount(type);indx++){
           sctl::Matrix<Real_t>& M=this->mat->Mat(l, type, indx);
           M.ReInit(0,0);

--- a/include/fmm_pts.txx
+++ b/include/fmm_pts.txx
@@ -292,7 +292,7 @@ void FMM_Pts<FMMNode>::Initialize(int mult_order, const sctl::Comm& comm_, const
   sctl::Profile::Tic("PrecompBC",&this->sctl_comm,false,4);
   { /*
     int type=BC_Type;
-    for(int l=0;l<PVFMM_MAX_DEPTH;l++)
+    for(int l=0;l<sctl::MAX_DEPTH;l++)
     for(size_t indx=0;indx<this->interac_list.ListCount((Mat_Type)type);indx++){
       sctl::Matrix<Real_t>& M=this->mat->Mat(l, (Mat_Type)type, indx);
       M.ReInit(0,0);
@@ -1267,7 +1267,7 @@ sctl::Matrix<typename FMMNode::Real_t>& FMM_Pts<FMMNode>::Precomp(int level, Mat
 template <class FMMNode>
 void FMM_Pts<FMMNode>::PrecompAll(Mat_Type type, int level){
   if(level==-1){
-    for(int l=0;l<PVFMM_MAX_DEPTH;l++){
+    for(int l=0;l<sctl::MAX_DEPTH;l++){
       PrecompAll(type, l);
     }
     return;
@@ -1326,7 +1326,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
     std::vector<sctl::Iterator<FMMNode_t>> node_lst;
     {// Construct node_lst
       node_lst.clear();
-      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(PVFMM_MAX_DEPTH+1);
+      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(sctl::MAX_DEPTH+1);
       sctl::Iterator<FMMNode_t> r_node=sctl::NullIterator<FMMNode_t>();
       for(size_t i=0;i<node.size();i++){
         if(!node[i]->IsLeaf()){
@@ -1339,7 +1339,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
         if(node[i]->Depth()==0) r_node=node[i];
       }
       size_t chld_cnt=1UL<<PVFMM_COORD_DIM;
-      for(int i=PVFMM_MAX_DEPTH;i>=0;i--){
+      for(int i=sctl::MAX_DEPTH;i>=0;i--){
         for(size_t j=0;j<node_lst_[i].size();j++){
           for(size_t k=0;k<chld_cnt;k++){
             sctl::Iterator<FMMNode_t> node=(sctl::Iterator<FMMNode_t>)node_lst_[i][j]->Child(k);
@@ -1347,7 +1347,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
           }
         }
       }
-      for(int i=0;i<=PVFMM_MAX_DEPTH;i++){
+      for(int i=0;i<=sctl::MAX_DEPTH;i++){
         for(size_t j=0;j<node_lst_[i].size();j++){
           if(node_lst_[i][j]->pt_cnt[0]){
             for(size_t k=0;k<chld_cnt;k++){
@@ -1386,7 +1386,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
     std::vector<sctl::Iterator<FMMNode_t>> node_lst;
     {// Construct node_lst
       node_lst.clear();
-      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(PVFMM_MAX_DEPTH+1);
+      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(sctl::MAX_DEPTH+1);
       sctl::Iterator<FMMNode_t> r_node=sctl::NullIterator<FMMNode_t>();
       for(size_t i=0;i<node.size();i++){
         if(!node[i]->IsLeaf()){
@@ -1397,7 +1397,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
         if(node[i]->Depth()==0) r_node=node[i];
       }
       size_t chld_cnt=1UL<<PVFMM_COORD_DIM;
-      for(int i=PVFMM_MAX_DEPTH;i>=0;i--){
+      for(int i=sctl::MAX_DEPTH;i>=0;i--){
         for(size_t j=0;j<node_lst_[i].size();j++){
           for(size_t k=0;k<chld_cnt;k++){
             sctl::Iterator<FMMNode_t> node=(sctl::Iterator<FMMNode_t>)node_lst_[i][j]->Child(k);
@@ -1405,7 +1405,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
           }
         }
       }
-      for(int i=0;i<=PVFMM_MAX_DEPTH;i++){
+      for(int i=0;i<=sctl::MAX_DEPTH;i++){
         for(size_t j=0;j<node_lst_[i].size();j++){
           if(node_lst_[i][j]->pt_cnt[1]){
             for(size_t k=0;k<chld_cnt;k++){
@@ -1436,11 +1436,11 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
     int indx=2;
     std::vector<sctl::Iterator<FMMNode_t>> node_lst;
     {
-      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(PVFMM_MAX_DEPTH+1);
+      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(sctl::MAX_DEPTH+1);
       for(size_t i=0;i<node.size();i++)
         if(!node[i]->IsLeaf())
           node_lst_[node[i]->Depth()].push_back(node[i]);
-      for(int i=0;i<=PVFMM_MAX_DEPTH;i++)
+      for(int i=0;i<=sctl::MAX_DEPTH;i++)
         for(size_t j=0;j<node_lst_[i].size();j++)
           node_lst.push_back(node_lst_[i][j]);
     }
@@ -1450,11 +1450,11 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
     int indx=3;
     std::vector<sctl::Iterator<FMMNode_t>> node_lst;
     {
-      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(PVFMM_MAX_DEPTH+1);
+      std::vector<std::vector<sctl::Iterator<FMMNode_t>>> node_lst_(sctl::MAX_DEPTH+1);
       for(size_t i=0;i<node.size();i++)
         if(!node[i]->IsLeaf() && !node[i]->IsGhost())
           node_lst_[node[i]->Depth()].push_back(node[i]);
-      for(int i=0;i<=PVFMM_MAX_DEPTH;i++)
+      for(int i=0;i<=sctl::MAX_DEPTH;i++)
         for(size_t j=0;j<node_lst_[i].size();j++)
           node_lst.push_back(node_lst_[i][j]);
     }
@@ -1552,11 +1552,11 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
     { // check and equiv surfaces.
       if(tree->upwd_check_surf.size()==0){
         size_t m=MultipoleOrder();
-        tree->upwd_check_surf.resize(PVFMM_MAX_DEPTH);
-        tree->upwd_equiv_surf.resize(PVFMM_MAX_DEPTH);
-        tree->dnwd_check_surf.resize(PVFMM_MAX_DEPTH);
-        tree->dnwd_equiv_surf.resize(PVFMM_MAX_DEPTH);
-        for(size_t depth=0;depth<PVFMM_MAX_DEPTH;depth++){
+        tree->upwd_check_surf.resize(sctl::MAX_DEPTH);
+        tree->upwd_equiv_surf.resize(sctl::MAX_DEPTH);
+        tree->dnwd_check_surf.resize(sctl::MAX_DEPTH);
+        tree->dnwd_equiv_surf.resize(sctl::MAX_DEPTH);
+        for(size_t depth=0;depth<sctl::MAX_DEPTH;depth++){
           Real_t c[3]={0.0,0.0,0.0};
           tree->upwd_check_surf[depth].ReInit((6*(m-1)*(m-1)+2)*PVFMM_COORD_DIM);
           tree->upwd_equiv_surf[depth].ReInit((6*(m-1)*(m-1)+2)*PVFMM_COORD_DIM);
@@ -1568,7 +1568,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
           tree->dnwd_equiv_surf[depth]=d_equiv_surf(m,c,depth);
         }
       }
-      for(size_t depth=0;depth<PVFMM_MAX_DEPTH;depth++){
+      for(size_t depth=0;depth<sctl::MAX_DEPTH;depth++){
         vec_lst.push_back(&tree->upwd_check_surf[depth]);
         vec_lst.push_back(&tree->upwd_equiv_surf[depth]);
         vec_lst.push_back(&tree->dnwd_check_surf[depth]);
@@ -1650,7 +1650,7 @@ void FMM_Pts<FMMNode>::CollectNodeData(FMMTree_t* tree, std::vector<sctl::Iterat
 
 template <class FMMNode>
 void FMM_Pts<FMMNode>::SetupPrecomp(SetupData<FMMNode_t>& setup_data, bool device){
-  if(setup_data.precomp_data==NULL || setup_data.level>PVFMM_MAX_DEPTH) return;
+  if(setup_data.precomp_data==NULL || setup_data.level>sctl::MAX_DEPTH) return;
 
   sctl::Profile::Tic("SetupPrecomp",&this->sctl_comm,true,25);
   if(setup_data.precomp_data_mirror) setup_data.precomp_data_mirror->Free(); // CompactData below may reallocate the host buffer
@@ -2237,7 +2237,7 @@ void FMM_Pts<FMMNode>::Source2UpSetup(SetupData<FMMNode_t>&  setup_data, FMMTree
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -2380,7 +2380,7 @@ void FMM_Pts<FMMNode>::Source2UpSetup(SetupData<FMMNode_t>&  setup_data, FMMTree
     std::vector<std::vector<size_t> > interac_cnt_(omp_p);
     if(this->ScaleInvar()){ // Set scal
       const Kernel<Real_t>* ker=kernel->k_m2m;
-      for(size_t l=0;l<PVFMM_MAX_DEPTH;l++){ // scal[l*4+2]
+      for(size_t l=0;l<sctl::MAX_DEPTH;l++){ // scal[l*4+2]
         sctl::Vector<Real_t>& scal=data.interac_data.scal[l*4+2];
         sctl::Vector<Real_t>& scal_exp=ker->trg_scal;
         scal.ReInit(scal_exp.Dim());
@@ -2388,7 +2388,7 @@ void FMM_Pts<FMMNode>::Source2UpSetup(SetupData<FMMNode_t>&  setup_data, FMMTree
           scal[i]=sctl::pow<Real_t>(2.0,-scal_exp[i]*l);
         }
       }
-      for(size_t l=0;l<PVFMM_MAX_DEPTH;l++){ // scal[l*4+3]
+      for(size_t l=0;l<sctl::MAX_DEPTH;l++){ // scal[l*4+3]
         sctl::Vector<Real_t>& scal=data.interac_data.scal[l*4+3];
         sctl::Vector<Real_t>& scal_exp=ker->src_scal;
         scal.ReInit(scal_exp.Dim());
@@ -3990,7 +3990,7 @@ void FMM_Pts<FMMNode>::PtSetup(SetupData<FMMNode_t>& setup_data, void* data_){
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -4068,7 +4068,7 @@ void FMM_Pts<FMMNode>::PtSetup(SetupData<FMMNode_t>& setup_data, void* data_){
       size_t      interac_cnt_size; size_t       interac_cnt_offset;
       size_t      interac_dsp_size; size_t       interac_dsp_offset;
       size_t      interac_cst_size; size_t       interac_cst_offset;
-      size_t scal_dim[4*PVFMM_MAX_DEPTH]; size_t scal_offset[4*PVFMM_MAX_DEPTH];
+      size_t scal_dim[4*sctl::MAX_DEPTH]; size_t scal_offset[4*sctl::MAX_DEPTH];
       size_t            Mdim[4][2]; size_t              M_offset[4];
     };
     PackedSetupData pkd_data;
@@ -4109,7 +4109,7 @@ void FMM_Pts<FMMNode>::PtSetup(SetupData<FMMNode_t>& setup_data, void* data_){
       pkd_data.interac_dsp_offset=offset; pkd_data.interac_dsp_size=intdata.interac_dsp.Dim(); offset+=mem::align_ptr(sizeof(size_t)*pkd_data.interac_dsp_size);
       pkd_data.interac_cst_offset=offset; pkd_data.interac_cst_size=intdata.interac_cst.Dim(); offset+=mem::align_ptr(sizeof(size_t)*pkd_data.interac_cst_size);
 
-      for(size_t i=0;i<4*PVFMM_MAX_DEPTH;i++){
+      for(size_t i=0;i<4*sctl::MAX_DEPTH;i++){
         pkd_data.scal_offset[i]=offset; pkd_data.scal_dim[i]=intdata.scal[i].Dim(); offset+=mem::align_ptr(sizeof(Real_t)*pkd_data.scal_dim[i]);
       }
       for(size_t i=0;i<4;i++){
@@ -4151,7 +4151,7 @@ void FMM_Pts<FMMNode>::PtSetup(SetupData<FMMNode_t>& setup_data, void* data_){
       if(pkd_data.interac_cnt_size) memcpy(&buff[0][pkd_data.interac_cnt_offset], &intdata.interac_cnt[0], pkd_data.interac_cnt_size*sizeof(size_t));
       if(pkd_data.interac_dsp_size) memcpy(&buff[0][pkd_data.interac_dsp_offset], &intdata.interac_dsp[0], pkd_data.interac_dsp_size*sizeof(size_t));
       if(pkd_data.interac_cst_size) memcpy(&buff[0][pkd_data.interac_cst_offset], &intdata.interac_cst[0], pkd_data.interac_cst_size*sizeof(size_t));
-      for(size_t i=0;i<4*PVFMM_MAX_DEPTH;i++){
+      for(size_t i=0;i<4*sctl::MAX_DEPTH;i++){
         if(intdata.scal[i].Dim()) memcpy(&buff[0][pkd_data.scal_offset[i]], &intdata.scal[i][0], intdata.scal[i].Dim()*sizeof(Real_t));
       }
       for(size_t i=0;i<4;i++){
@@ -4227,7 +4227,7 @@ void FMM_Pts<FMMNode>::EvalListPts(SetupData<FMMNode_t>& setup_data, bool device
       sctl::Vector<size_t> interac_cnt;
       sctl::Vector<size_t> interac_dsp;
       sctl::Vector<size_t> interac_cst;
-      sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+      sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
       sctl::Matrix<Real_t> M[4];
     };
     struct ptSetupData{
@@ -4281,7 +4281,7 @@ void FMM_Pts<FMMNode>::EvalListPts(SetupData<FMMNode_t>& setup_data, bool device
         size_t      interac_cnt_size; size_t       interac_cnt_offset;
         size_t      interac_dsp_size; size_t       interac_dsp_offset;
         size_t      interac_cst_size; size_t       interac_cst_offset;
-        size_t scal_dim[4*PVFMM_MAX_DEPTH]; size_t scal_offset[4*PVFMM_MAX_DEPTH];
+        size_t scal_dim[4*sctl::MAX_DEPTH]; size_t scal_offset[4*sctl::MAX_DEPTH];
         size_t            Mdim[4][2]; size_t              M_offset[4];
       };
       DeviceMatrix<char>& setupdata=interac_data;
@@ -4321,7 +4321,7 @@ void FMM_Pts<FMMNode>::EvalListPts(SetupData<FMMNode_t>& setup_data, bool device
       intdata.interac_cnt.ReInit(pkd_data.interac_cnt_size, sctl::Ptr2Itr<size_t>((size_t*)&setupdata[0][pkd_data.interac_cnt_offset], pkd_data.interac_cnt_size), false);
       intdata.interac_dsp.ReInit(pkd_data.interac_dsp_size, sctl::Ptr2Itr<size_t>((size_t*)&setupdata[0][pkd_data.interac_dsp_offset], pkd_data.interac_dsp_size), false);
       intdata.interac_cst.ReInit(pkd_data.interac_cst_size, sctl::Ptr2Itr<size_t>((size_t*)&setupdata[0][pkd_data.interac_cst_offset], pkd_data.interac_cst_size), false);
-      for(size_t i=0;i<4*PVFMM_MAX_DEPTH;i++){
+      for(size_t i=0;i<4*sctl::MAX_DEPTH;i++){
         intdata.scal[i].ReInit(pkd_data.scal_dim[i], sctl::Ptr2Itr<Real_t>((Real_t*)&setupdata[0][pkd_data.scal_offset[i]], pkd_data.scal_dim[i]),false);
       }
       for(size_t i=0;i<4;i++){
@@ -4642,7 +4642,7 @@ void FMM_Pts<FMMNode>::X_ListSetup(SetupData<FMMNode_t>&  setup_data, FMMTree_t*
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -4947,7 +4947,7 @@ void FMM_Pts<FMMNode>::W_ListSetup(SetupData<FMMNode_t>&  setup_data, FMMTree_t*
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -5235,7 +5235,7 @@ void FMM_Pts<FMMNode>::U_ListSetup(SetupData<FMMNode_t>& setup_data, FMMTree_t* 
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -5634,7 +5634,7 @@ void FMM_Pts<FMMNode>::Down2TargetSetup(SetupData<FMMNode_t>&  setup_data, FMMTr
     sctl::Vector<size_t> interac_cnt;
     sctl::Vector<size_t> interac_dsp;
     sctl::Vector<size_t> interac_cst;
-    sctl::Vector<Real_t> scal[4*PVFMM_MAX_DEPTH];
+    sctl::Vector<Real_t> scal[4*sctl::MAX_DEPTH];
     sctl::Matrix<Real_t> M[4];
   };
   struct ptSetupData{
@@ -5763,7 +5763,7 @@ void FMM_Pts<FMMNode>::Down2TargetSetup(SetupData<FMMNode_t>&  setup_data, FMMTr
     std::vector<std::vector<size_t> > interac_cnt_(omp_p);
     if(this->ScaleInvar()){ // Set scal
       const Kernel<Real_t>* ker=kernel->k_l2l;
-      for(size_t l=0;l<PVFMM_MAX_DEPTH;l++){ // scal[l*4+0]
+      for(size_t l=0;l<sctl::MAX_DEPTH;l++){ // scal[l*4+0]
         sctl::Vector<Real_t>& scal=data.interac_data.scal[l*4+0];
         sctl::Vector<Real_t>& scal_exp=ker->trg_scal;
         scal.ReInit(scal_exp.Dim());
@@ -5771,7 +5771,7 @@ void FMM_Pts<FMMNode>::Down2TargetSetup(SetupData<FMMNode_t>&  setup_data, FMMTr
           scal[i]=sctl::pow<Real_t>(2.0,-scal_exp[i]*l);
         }
       }
-      for(size_t l=0;l<PVFMM_MAX_DEPTH;l++){ // scal[l*4+1]
+      for(size_t l=0;l<sctl::MAX_DEPTH;l++){ // scal[l*4+1]
         sctl::Vector<Real_t>& scal=data.interac_data.scal[l*4+1];
         sctl::Vector<Real_t>& scal_exp=ker->src_scal;
         scal.ReInit(scal_exp.Dim());

--- a/include/fmm_tree.txx
+++ b/include/fmm_tree.txx
@@ -122,65 +122,65 @@ void FMM_Tree<FMM_Mat_t>::SetupFMM(FMM_Mat_t* fmm_mat_) {
   BuildInteracLists();
   sctl::Profile::Toc();
 
-  setup_data.resize(8*PVFMM_MAX_DEPTH);
+  setup_data.resize(8*sctl::MAX_DEPTH);
   precomp_lst.resize(8);
   precomp_lst_mirror.resize(8);
 
   sctl::Profile::Tic("UListSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*0].precomp_data=&precomp_lst[0];
-    setup_data[i+PVFMM_MAX_DEPTH*0].precomp_data_mirror=&precomp_lst_mirror[0];
-    fmm_mat->U_ListSetup(setup_data[i+PVFMM_MAX_DEPTH*0],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, device);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*0].precomp_data=&precomp_lst[0];
+    setup_data[i+sctl::MAX_DEPTH*0].precomp_data_mirror=&precomp_lst_mirror[0];
+    fmm_mat->U_ListSetup(setup_data[i+sctl::MAX_DEPTH*0],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, device);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("WListSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*1].precomp_data=&precomp_lst[1];
-    setup_data[i+PVFMM_MAX_DEPTH*1].precomp_data_mirror=&precomp_lst_mirror[1];
-    fmm_mat->W_ListSetup(setup_data[i+PVFMM_MAX_DEPTH*1],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, device);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*1].precomp_data=&precomp_lst[1];
+    setup_data[i+sctl::MAX_DEPTH*1].precomp_data_mirror=&precomp_lst_mirror[1];
+    fmm_mat->W_ListSetup(setup_data[i+sctl::MAX_DEPTH*1],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, device);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("XListSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*2].precomp_data=&precomp_lst[2];
-    setup_data[i+PVFMM_MAX_DEPTH*2].precomp_data_mirror=&precomp_lst_mirror[2];
-    fmm_mat->X_ListSetup(setup_data[i+PVFMM_MAX_DEPTH*2],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, device);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*2].precomp_data=&precomp_lst[2];
+    setup_data[i+sctl::MAX_DEPTH*2].precomp_data_mirror=&precomp_lst_mirror[2];
+    fmm_mat->X_ListSetup(setup_data[i+sctl::MAX_DEPTH*2],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, device);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("VListSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*3].precomp_data=&precomp_lst[3];
-    setup_data[i+PVFMM_MAX_DEPTH*3].precomp_data_mirror=&precomp_lst_mirror[3];
-    fmm_mat->V_ListSetup(setup_data[i+PVFMM_MAX_DEPTH*3],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, /*device*/ false);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*3].precomp_data=&precomp_lst[3];
+    setup_data[i+sctl::MAX_DEPTH*3].precomp_data_mirror=&precomp_lst_mirror[3];
+    fmm_mat->V_ListSetup(setup_data[i+sctl::MAX_DEPTH*3],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, /*device*/ false);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("D2DSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*4].precomp_data=&precomp_lst[4];
-    setup_data[i+PVFMM_MAX_DEPTH*4].precomp_data_mirror=&precomp_lst_mirror[4];
-    fmm_mat->Down2DownSetup(setup_data[i+PVFMM_MAX_DEPTH*4],(MatTree_t*)this,node_data_buff,node_lists,i, /*device*/ false);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*4].precomp_data=&precomp_lst[4];
+    setup_data[i+sctl::MAX_DEPTH*4].precomp_data_mirror=&precomp_lst_mirror[4];
+    fmm_mat->Down2DownSetup(setup_data[i+sctl::MAX_DEPTH*4],(MatTree_t*)this,node_data_buff,node_lists,i, /*device*/ false);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("D2TSetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*5].precomp_data=&precomp_lst[5];
-    setup_data[i+PVFMM_MAX_DEPTH*5].precomp_data_mirror=&precomp_lst_mirror[5];
-    fmm_mat->Down2TargetSetup(setup_data[i+PVFMM_MAX_DEPTH*5],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, /*device*/ false);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*5].precomp_data=&precomp_lst[5];
+    setup_data[i+sctl::MAX_DEPTH*5].precomp_data_mirror=&precomp_lst_mirror[5];
+    fmm_mat->Down2TargetSetup(setup_data[i+sctl::MAX_DEPTH*5],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, /*device*/ false);
   }
   sctl::Profile::Toc();
 
   sctl::Profile::Tic("S2USetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*6].precomp_data=&precomp_lst[6];
-    setup_data[i+PVFMM_MAX_DEPTH*6].precomp_data_mirror=&precomp_lst_mirror[6];
-    fmm_mat->Source2UpSetup(setup_data[i+PVFMM_MAX_DEPTH*6],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:PVFMM_MAX_DEPTH+1):i, /*device*/ false);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*6].precomp_data=&precomp_lst[6];
+    setup_data[i+sctl::MAX_DEPTH*6].precomp_data_mirror=&precomp_lst_mirror[6];
+    fmm_mat->Source2UpSetup(setup_data[i+sctl::MAX_DEPTH*6],(MatTree_t*)this,node_data_buff,node_lists,fmm_mat->ScaleInvar()?(i==0?-1:sctl::MAX_DEPTH+1):i, /*device*/ false);
   }
   sctl::Profile::Toc();
   sctl::Profile::Tic("U2USetup",&this->Comm(),false,3);
-  for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
-    setup_data[i+PVFMM_MAX_DEPTH*7].precomp_data=&precomp_lst[7];
-    setup_data[i+PVFMM_MAX_DEPTH*7].precomp_data_mirror=&precomp_lst_mirror[7];
-    fmm_mat->Up2UpSetup(setup_data[i+PVFMM_MAX_DEPTH*7],(MatTree_t*)this,node_data_buff,node_lists,i, /*device*/ false);
+  for(size_t i=0;i<sctl::MAX_DEPTH;i++){
+    setup_data[i+sctl::MAX_DEPTH*7].precomp_data=&precomp_lst[7];
+    setup_data[i+sctl::MAX_DEPTH*7].precomp_data_mirror=&precomp_lst_mirror[7];
+    fmm_mat->Up2UpSetup(setup_data[i+sctl::MAX_DEPTH*7],(MatTree_t*)this,node_data_buff,node_lists,i, /*device*/ false);
   }
   sctl::Profile::Toc();
 
@@ -199,21 +199,21 @@ void FMM_Tree<FMM_Mat_t>::ClearFMMData() {
   for(int j=0;j<omp_p;j++){
     sctl::Matrix<Real_t>* mat;
 
-    mat=setup_data[0+PVFMM_MAX_DEPTH*1]. input_data;
+    mat=setup_data[0+sctl::MAX_DEPTH*1]. input_data;
     if(mat && mat->Dim(0)*mat->Dim(1)>0){
       size_t a=(mat->Dim(0)*mat->Dim(1)*(j+0))/omp_p;
       size_t b=(mat->Dim(0)*mat->Dim(1)*(j+1))/omp_p;
       ::memset(&(*mat)[0][a],0,(b-a)*sizeof(Real_t));
     }
 
-    mat=setup_data[0+PVFMM_MAX_DEPTH*2].output_data;
+    mat=setup_data[0+sctl::MAX_DEPTH*2].output_data;
     if(mat && mat->Dim(0)*mat->Dim(1)>0){
       size_t a=(mat->Dim(0)*mat->Dim(1)*(j+0))/omp_p;
       size_t b=(mat->Dim(0)*mat->Dim(1)*(j+1))/omp_p;
       ::memset(&(*mat)[0][a],0,(b-a)*sizeof(Real_t));
     }
 
-    mat=setup_data[0+PVFMM_MAX_DEPTH*0].output_data;
+    mat=setup_data[0+sctl::MAX_DEPTH*0].output_data;
     if(mat && mat->Dim(0)*mat->Dim(1)>0){
       size_t a=(mat->Dim(0)*mat->Dim(1)*(j+0))/omp_p;
       size_t b=(mat->Dim(0)*mat->Dim(1)*(j+1))/omp_p;
@@ -222,9 +222,9 @@ void FMM_Tree<FMM_Mat_t>::ClearFMMData() {
   }
 
   if(device){ // Host2Device
-    if(setup_data[0+PVFMM_MAX_DEPTH*1]. input_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*1]. input_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*1]. input_data,true);
-    if(setup_data[0+PVFMM_MAX_DEPTH*2].output_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*2].output_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*2].output_data,true);
-    if(setup_data[0+PVFMM_MAX_DEPTH*0].output_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*0].output_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*0].output_data,true);
+    if(setup_data[0+sctl::MAX_DEPTH*1]. input_data!=NULL) setup_data[0+sctl::MAX_DEPTH*1]. input_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*1]. input_data,true);
+    if(setup_data[0+sctl::MAX_DEPTH*2].output_data!=NULL) setup_data[0+sctl::MAX_DEPTH*2].output_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*2].output_data,true);
+    if(setup_data[0+sctl::MAX_DEPTH*0].output_data!=NULL) setup_data[0+sctl::MAX_DEPTH*0].output_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*0].output_data,true);
   }
 
   }sctl::Profile::Toc();
@@ -279,16 +279,16 @@ void FMM_Tree<FMM_Mat_t>::UpwardPass() {
   //Upward Pass (initialize all leaf nodes)
   sctl::Profile::Tic("S2U",&this->Comm(),false,5);
   for(int i=0; i<=(fmm_mat->ScaleInvar()?0:max_depth); i++){ // Source2Up
-    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*6],/*device*/ false);
-    fmm_mat->Source2Up(setup_data[i+PVFMM_MAX_DEPTH*6]);
+    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*6],/*device*/ false);
+    fmm_mat->Source2Up(setup_data[i+sctl::MAX_DEPTH*6]);
   }
   sctl::Profile::Toc();
 
   //Upward Pass (level by level)
   sctl::Profile::Tic("U2U",&this->Comm(),false,5);
   for(int i=max_depth-1; i>=0; i--){ // Up2Up
-    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*7],/*device*/ false);
-    fmm_mat->Up2Up(setup_data[i+PVFMM_MAX_DEPTH*7]);
+    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*7],/*device*/ false);
+    fmm_mat->Up2Up(setup_data[i+sctl::MAX_DEPTH*7]);
   }
   sctl::Profile::Toc();
 }
@@ -586,8 +586,8 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
   #if defined(PVFMM_HAVE_CUDA)
   if(device){ // Host2Device:Src
     sctl::Profile::Tic("Host2Device:Src",&this->Comm(),false,5);
-    if(setup_data[0+PVFMM_MAX_DEPTH*2]. coord_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*2]. coord_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*2]. coord_data,true);
-    if(setup_data[0+PVFMM_MAX_DEPTH*2]. input_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*2]. input_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*2]. input_data,true);
+    if(setup_data[0+sctl::MAX_DEPTH*2]. coord_data!=NULL) setup_data[0+sctl::MAX_DEPTH*2]. coord_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*2]. coord_data,true);
+    if(setup_data[0+sctl::MAX_DEPTH*2]. input_data!=NULL) setup_data[0+sctl::MAX_DEPTH*2]. input_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*2]. input_data,true);
     sctl::Profile::Toc();
   }
   #endif
@@ -606,22 +606,22 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
       sctl::Profile::Tic("Precomp",&this->Comm(),false,5);
       {// Precomp U
         sctl::Profile::Tic("Precomp-U",&this->Comm(),false,10);
-        fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*0],device);
+        fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*0],device);
         sctl::Profile::Toc();
       }
       {// Precomp W
         sctl::Profile::Tic("Precomp-W",&this->Comm(),false,10);
-        fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*1],device);
+        fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*1],device);
         sctl::Profile::Toc();
       }
       {// Precomp X
         sctl::Profile::Tic("Precomp-X",&this->Comm(),false,10);
-        fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*2],device);
+        fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*2],device);
         sctl::Profile::Toc();
       }
       if(0){// Precomp V
         sctl::Profile::Tic("Precomp-V",&this->Comm(),false,10);
-        fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*3], /*device*/ false);
+        fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*3], /*device*/ false);
         sctl::Profile::Toc();
       }
       sctl::Profile::Toc();
@@ -629,24 +629,24 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
 
     {// X-List
       sctl::Profile::Tic("X-List",&this->Comm(),false,5);
-      fmm_mat->X_List(setup_data[i+PVFMM_MAX_DEPTH*2], device);
+      fmm_mat->X_List(setup_data[i+sctl::MAX_DEPTH*2], device);
       sctl::Profile::Toc();
     }
 
     #if defined(PVFMM_HAVE_CUDA)
     if(i==0 && device){ // Host2Device:Mult
       sctl::Profile::Tic("Host2Device:Mult",&this->Comm(),false,5);
-      if(setup_data[0+PVFMM_MAX_DEPTH*1]. input_data!=NULL) setup_data[0+PVFMM_MAX_DEPTH*1]. input_data_mirror->AllocDevice(*setup_data[0+PVFMM_MAX_DEPTH*1]. input_data,true);
+      if(setup_data[0+sctl::MAX_DEPTH*1]. input_data!=NULL) setup_data[0+sctl::MAX_DEPTH*1]. input_data_mirror->AllocDevice(*setup_data[0+sctl::MAX_DEPTH*1]. input_data,true);
       sctl::Profile::Toc();
     }
 
     if(device) if(i==(fmm_mat->ScaleInvar()?0:max_depth)){ // Device2Host: LocalExp
       sctl::Profile::Tic("Device2Host:LocExp",&this->Comm(),false,5);
-      if(setup_data[0+PVFMM_MAX_DEPTH*2].output_data!=NULL){
-        sctl::Matrix<Real_t>& output_data=*setup_data[0+PVFMM_MAX_DEPTH*2].output_data;
+      if(setup_data[0+sctl::MAX_DEPTH*2].output_data!=NULL){
+        sctl::Matrix<Real_t>& output_data=*setup_data[0+sctl::MAX_DEPTH*2].output_data;
         if(fmm_mat->staging_buffer.Dim()){
           assert(fmm_mat->staging_buffer.Dim()*(sctl::Long)sizeof(Real_t)>=output_data.Dim(0)*output_data.Dim(1));
-          setup_data[0+PVFMM_MAX_DEPTH*2].output_data_mirror->Device2Host((char*)&fmm_mat->staging_buffer[0]);
+          setup_data[0+sctl::MAX_DEPTH*2].output_data_mirror->Device2Host((char*)&fmm_mat->staging_buffer[0]);
         }
       }
       sctl::Profile::Toc();
@@ -655,19 +655,19 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
 
     {// W-List
       sctl::Profile::Tic("W-List",&this->Comm(),false,5);
-      fmm_mat->W_List(setup_data[i+PVFMM_MAX_DEPTH*1], device);
+      fmm_mat->W_List(setup_data[i+sctl::MAX_DEPTH*1], device);
       sctl::Profile::Toc();
     }
 
     {// U-List
       sctl::Profile::Tic("U-List",&this->Comm(),false,5);
-      fmm_mat->U_List(setup_data[i+PVFMM_MAX_DEPTH*0], device);
+      fmm_mat->U_List(setup_data[i+sctl::MAX_DEPTH*0], device);
       sctl::Profile::Toc();
     }
 
     {// V-List
       sctl::Profile::Tic("V-List",&this->Comm(),false,5);
-      fmm_mat->V_List(setup_data[i+PVFMM_MAX_DEPTH*3], /*device*/ false);
+      fmm_mat->V_List(setup_data[i+sctl::MAX_DEPTH*3], /*device*/ false);
       sctl::Profile::Toc();
     }
 
@@ -678,13 +678,13 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
 
   #if defined(PVFMM_HAVE_CUDA)
   sctl::Profile::Tic("D2H_Wait:LocExp",&this->Comm(),false,5);
-  if(device) if(setup_data[0+PVFMM_MAX_DEPTH*2].output_data!=NULL){
+  if(device) if(setup_data[0+sctl::MAX_DEPTH*2].output_data!=NULL){
     if(fmm_mat->staging_buffer.Dim()){
       Real_t* dev_ptr=(Real_t*)&fmm_mat->staging_buffer[0];
-      sctl::Matrix<Real_t>& output_data=*setup_data[0+PVFMM_MAX_DEPTH*2].output_data;
+      sctl::Matrix<Real_t>& output_data=*setup_data[0+sctl::MAX_DEPTH*2].output_data;
       size_t n=output_data.Dim(0)*output_data.Dim(1);
       Real_t* host_ptr=&output_data[0][0];
-      setup_data[0+PVFMM_MAX_DEPTH*2].output_data_mirror->Device2HostWait();
+      setup_data[0+sctl::MAX_DEPTH*2].output_data_mirror->Device2HostWait();
 
       #pragma omp parallel for
       for(size_t i=0;i<n;i++){
@@ -695,11 +695,11 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
   sctl::Profile::Toc();
 
   sctl::Profile::Tic("Device2Host:Trg",&this->Comm(),false,5);
-  if(device) if(setup_data[0+PVFMM_MAX_DEPTH*0].output_data!=NULL){ // Device2Host: Target
-    sctl::Matrix<Real_t>& output_data=*setup_data[0+PVFMM_MAX_DEPTH*0].output_data;
+  if(device) if(setup_data[0+sctl::MAX_DEPTH*0].output_data!=NULL){ // Device2Host: Target
+    sctl::Matrix<Real_t>& output_data=*setup_data[0+sctl::MAX_DEPTH*0].output_data;
     if(fmm_mat->staging_buffer.Dim()){
       assert(fmm_mat->staging_buffer.Dim()>=(sctl::Long)sizeof(Real_t)*output_data.Dim(0)*output_data.Dim(1));
-      setup_data[0+PVFMM_MAX_DEPTH*0].output_data_mirror->Device2Host((char*)&fmm_mat->staging_buffer[0]);
+      setup_data[0+sctl::MAX_DEPTH*0].output_data_mirror->Device2Host((char*)&fmm_mat->staging_buffer[0]);
     }
   }
   sctl::Profile::Toc();
@@ -707,27 +707,27 @@ void FMM_Tree<FMM_Mat_t>::DownwardPass() {
 
   sctl::Profile::Tic("D2D",&this->Comm(),false,5);
   for(int i=0; i<=max_depth; i++){ // Down2Down
-    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*4],/*device*/ false);
-    fmm_mat->Down2Down(setup_data[i+PVFMM_MAX_DEPTH*4]);
+    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*4],/*device*/ false);
+    fmm_mat->Down2Down(setup_data[i+sctl::MAX_DEPTH*4]);
   }
   sctl::Profile::Toc();
 
   sctl::Profile::Tic("D2T",&this->Comm(),false,5);
   for(int i=0; i<=(fmm_mat->ScaleInvar()?0:max_depth); i++){ // Down2Target
-    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+PVFMM_MAX_DEPTH*5],/*device*/ false);
-    fmm_mat->Down2Target(setup_data[i+PVFMM_MAX_DEPTH*5]);
+    if(!fmm_mat->ScaleInvar()) fmm_mat->SetupPrecomp(setup_data[i+sctl::MAX_DEPTH*5],/*device*/ false);
+    fmm_mat->Down2Target(setup_data[i+sctl::MAX_DEPTH*5]);
   }
   sctl::Profile::Toc();
 
   #if defined(PVFMM_HAVE_CUDA)
   sctl::Profile::Tic("D2H_Wait:Trg",&this->Comm(),false,5);
-  if(device) if(setup_data[0+PVFMM_MAX_DEPTH*0].output_data!=NULL){
+  if(device) if(setup_data[0+sctl::MAX_DEPTH*0].output_data!=NULL){
     if(fmm_mat->staging_buffer.Dim()){
       Real_t* dev_ptr=(Real_t*)&fmm_mat->staging_buffer[0];
-      sctl::Matrix<Real_t>& output_data=*setup_data[0+PVFMM_MAX_DEPTH*0].output_data;
+      sctl::Matrix<Real_t>& output_data=*setup_data[0+sctl::MAX_DEPTH*0].output_data;
       size_t n=output_data.Dim(0)*output_data.Dim(1);
       Real_t* host_ptr=&output_data[0][0];
-      setup_data[0+PVFMM_MAX_DEPTH*0].output_data_mirror->Device2HostWait();
+      setup_data[0+sctl::MAX_DEPTH*0].output_data_mirror->Device2HostWait();
 
       #pragma omp parallel for
       for(size_t i=0;i<n;i++){

--- a/include/mpi_node.txx
+++ b/include/mpi_node.txx
@@ -60,7 +60,7 @@ void MPI_Node<T>::ClearData(){
 template <class T>
 MortonId MPI_Node<T>::GetMortonId(){
   assert(coord);
-  Real_t s=0.25/(1UL<<PVFMM_MAX_DEPTH);
+  Real_t s=0.25/(1UL<<sctl::MAX_DEPTH);
   sctl::StaticArray<Real_t,3> mc{coord[0]+s,coord[1]+s,coord[2]+s}; // TODO: Use integer coordinates instead of floating point.
   return MortonId((sctl::ConstIterator<Real_t>)mc, Depth());
 }

--- a/include/mpi_tree.txx
+++ b/include/mpi_tree.txx
@@ -43,7 +43,7 @@ struct SortPair{
  */
 inline int p2oLocal(sctl::Vector<MortonId> & nodes, sctl::Vector<MortonId>& leaves,
     unsigned int maxNumPts, unsigned int maxDepth, bool complete) {
-  assert(maxDepth<=PVFMM_MAX_DEPTH);
+  assert(maxDepth<=sctl::MAX_DEPTH);
 
   std::vector<MortonId> leaves_lst;
   unsigned int init_size=leaves.Dim();
@@ -1139,12 +1139,12 @@ void MPI_Tree<TreeNode>::SetColleagues(BoundaryType bndry, Node_t* node){
       curr_node=this->PreorderNxt(curr_node);
     }
 
-    sctl::Vector<std::vector<Node_t*> > nodes(PVFMM_MAX_DEPTH);
+    sctl::Vector<std::vector<Node_t*> > nodes(sctl::MAX_DEPTH);
     while(curr_node!=sctl::NullIterator<Node_t>()){
       nodes[curr_node->Depth()].push_back(&curr_node[0]);
       curr_node=this->PreorderNxt(curr_node);
     }
-    for(size_t i=0;i<PVFMM_MAX_DEPTH;i++){
+    for(size_t i=0;i<sctl::MAX_DEPTH;i++){
       size_t j0=nodes[i].size();
       auto& nodes_=nodes[i];
       #pragma omp parallel for

--- a/include/pvfmm.txx
+++ b/include/pvfmm.txx
@@ -26,7 +26,7 @@ inline ChebFMM_Tree<Real>* ChebFMM_CreateTree(int cheb_deg, int data_dim, ChebFn
   bool adap=true;
 
   tree_data.dim=PVFMM_COORD_DIM;
-  tree_data.max_depth=PVFMM_MAX_DEPTH;
+  tree_data.max_depth=sctl::MAX_DEPTH;
   tree_data.max_pts=max_pts;
 
   { // Set points for initial tree.
@@ -62,7 +62,7 @@ inline ChebFMM_Tree<Real>* ChebFMM_CreateTree(int cheb_deg, const std::vector<Re
   bool adap=false;
 
   tree_data.dim=PVFMM_COORD_DIM;
-  tree_data.max_depth=PVFMM_MAX_DEPTH;
+  tree_data.max_depth=sctl::MAX_DEPTH;
   tree_data.max_pts=1;
 
   tree_data.cheb_deg=cheb_deg;
@@ -216,7 +216,7 @@ inline PtFMM_Tree<Real>* PtFMM_CreateTree(const std::vector<Real>&  src_coord, c
   bool adap=true;
 
   tree_data.dim=PVFMM_COORD_DIM;
-  tree_data.max_depth=PVFMM_MAX_DEPTH;
+  tree_data.max_depth=sctl::MAX_DEPTH;
   tree_data.max_pts=max_pts;
 
   // Set source points.

--- a/include/pvfmm_common.hpp
+++ b/include/pvfmm_common.hpp
@@ -34,7 +34,8 @@
 //Verbose (sctl::Profile stdout output + pvfmm diagnostics; enable with -DSCTL_VERBOSE)
 //#define SCTL_VERBOSE
 
-#define PVFMM_MAX_DEPTH 30
+// Octree depth is limited by what sctl::Morton can encode; use sctl::MAX_DEPTH directly
+// rather than a second constant that could drift from it.
 
 #define PVFMM_BC_LEVELS 45
 
@@ -80,12 +81,6 @@ inline uintptr_t align_ptr(uintptr_t ptr){
 }
 }//end namespace
 }//end namespace
-
-// Keep sctl::Morton<3>'s depth range in lock-step with pvfmm's octree depth
-// (must be set before sctl.hpp so sctl::MortonCode picks the right code width).
-#ifndef SCTL_MAX_DEPTH
-#define SCTL_MAX_DEPTH PVFMM_MAX_DEPTH
-#endif
 
 #include <sctl.hpp>
 

--- a/include/tree.hpp
+++ b/include/tree.hpp
@@ -30,7 +30,7 @@ class Tree{
   /**
    * \brief Constructor.
    */
-  Tree(): dim(0), root_node(sctl::NullIterator<Node_t>()), max_depth(PVFMM_MAX_DEPTH) { };
+  Tree(): dim(0), root_node(sctl::NullIterator<Node_t>()), max_depth(sctl::MAX_DEPTH) { };
 
   /**
    * \brief Virtual destructor.

--- a/include/tree.txx
+++ b/include/tree.txx
@@ -18,7 +18,7 @@ template <class TreeNode>
 void Tree<TreeNode>::Initialize(typename Node_t::NodeData* init_data_){
   dim=init_data_->dim;
   max_depth=init_data_->max_depth;
-  if(max_depth>PVFMM_MAX_DEPTH) max_depth=PVFMM_MAX_DEPTH;
+  if(max_depth>sctl::MAX_DEPTH) max_depth=sctl::MAX_DEPTH;
 
   if(root_node!=sctl::NullIterator<Node_t>()) sctl::aligned_delete(root_node);
   root_node=sctl::aligned_new<Node_t>();

--- a/include/tree_node.hpp
+++ b/include/tree_node.hpp
@@ -38,7 +38,7 @@ class TreeNode{
   /**
    * \brief Initialize pointers to NULL
    */
-  TreeNode(): dim(0), depth(0), max_depth(PVFMM_MAX_DEPTH), parent(sctl::NullIterator<TreeNode>()), child(sctl::NullIterator<sctl::Iterator<TreeNode>>()), status(1) { }
+  TreeNode(): dim(0), depth(0), max_depth(sctl::MAX_DEPTH), parent(sctl::NullIterator<TreeNode>()), child(sctl::NullIterator<sctl::Iterator<TreeNode>>()), status(1) { }
 
   /**
    * \brief Virtual destructor

--- a/include/tree_node.txx
+++ b/include/tree_node.txx
@@ -27,7 +27,7 @@ inline void TreeNode::Initialize(sctl::Iterator<TreeNode> parent_, int path2node
   if(data_!=NULL){
     dim=data_->dim;
     max_depth=data_->max_depth;
-    if(max_depth>PVFMM_MAX_DEPTH) max_depth=PVFMM_MAX_DEPTH;
+    if(max_depth>sctl::MAX_DEPTH) max_depth=sctl::MAX_DEPTH;
   }else if(parent!=sctl::NullIterator<TreeNode>()){
     dim=parent->dim;
     max_depth=parent->max_depth;

--- a/src/pvfmm-wrapper.cpp
+++ b/src/pvfmm-wrapper.cpp
@@ -765,8 +765,8 @@ template<typename Real> static void PVFMMEval(const Real* src_pos, const Real* s
       myrank = ctx->sctl_comm.Rank();
 
       long nleaf=0, maxdepth=0;
-      std::vector<size_t> all_nodes(PVFMM_MAX_DEPTH+1,0);
-      std::vector<size_t> leaf_nodes(PVFMM_MAX_DEPTH+1,0);
+      std::vector<size_t> all_nodes(sctl::MAX_DEPTH+1,0);
+      std::vector<size_t> leaf_nodes(sctl::MAX_DEPTH+1,0);
       std::vector<sctl::Iterator<Node_t>>& nodes=ctx->tree->GetNodeList();
       for(size_t i=0;i<nodes.size();i++){
         sctl::Iterator<Node_t> n=nodes[i];
@@ -780,7 +780,7 @@ template<typename Real> static void PVFMMEval(const Real* src_pos, const Real* s
 
       std::stringstream os1,os2;
       os1<<"All Nodes";
-      for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+      for(int i=0;i<sctl::MAX_DEPTH;i++){
         int local_size=all_nodes[i];
         int global_size;
         ctx->sctl_comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size,1), sctl::Ptr2Itr<int>(&global_size,1), 1, sctl::CommOp::SUM);
@@ -789,7 +789,7 @@ template<typename Real> static void PVFMMEval(const Real* src_pos, const Real* s
       if(!myrank) std::cout<<os1.str()<<'\n';
 
       os2<<"Leaf Nodes: ";
-      for(int i=0;i<PVFMM_MAX_DEPTH;i++){
+      for(int i=0;i<sctl::MAX_DEPTH;i++){
         int local_size=leaf_nodes[i];
         int global_size;
         ctx->sctl_comm.Allreduce(sctl::Ptr2ConstItr<int>(&local_size,1), sctl::Ptr2Itr<int>(&global_size,1), 1, sctl::CommOp::SUM);
@@ -877,7 +877,7 @@ void pvfmmevalf_(const float* src_pos, const float* sl_den, int64_t* n_src, cons
 // Create single-precision particle FMM context
 void pvfmmcreatecontextf_(void** ctx, float* box_size, int32_t* n, int32_t* m, int32_t* kernel, int32_t* bndry, MPI_Fint* fcomm) {
   MPI_Comm comm = MPI_Comm_f2c(*fcomm);
-  (*ctx) = PVFMMCreateContext<float>(*box_size, *n, *m, PVFMM_MAX_DEPTH, PVFMMKernelPtr<float>((enum PVFMMKernel)*kernel), PVFMMBndry(*bndry), comm);
+  (*ctx) = PVFMMCreateContext<float>(*box_size, *n, *m, sctl::MAX_DEPTH, PVFMMKernelPtr<float>((enum PVFMMKernel)*kernel), PVFMMBndry(*bndry), comm);
 }
 
 // Destroy single-precision particle FMM context
@@ -894,7 +894,7 @@ void pvfmmevald_(const double* src_pos, const double* sl_den, int64_t* n_src, co
 // Create double-precision particle FMM context
 void pvfmmcreatecontextd_(void** ctx, double* box_size, int32_t* n, int32_t* m, int32_t* kernel, int32_t* bndry, MPI_Fint* fcomm) {
   MPI_Comm comm = MPI_Comm_f2c(*fcomm);
-  (*ctx) = PVFMMCreateContext<double>(*box_size, *n, *m, PVFMM_MAX_DEPTH, PVFMMKernelPtr<double>((enum PVFMMKernel)*kernel), PVFMMBndry(*bndry), comm);
+  (*ctx) = PVFMMCreateContext<double>(*box_size, *n, *m, sctl::MAX_DEPTH, PVFMMKernelPtr<double>((enum PVFMMKernel)*kernel), PVFMMBndry(*bndry), comm);
 }
 
 // Destroy double-precision particle FMM context
@@ -906,7 +906,7 @@ void pvfmmdestroycontextd_(void** ctx) {
 
 
 void* PVFMMCreateContextF(float box_size, int n, int m, enum PVFMMKernel kernel, enum PVFMMBoundaryType bndry, MPI_Comm comm) {
-  return PVFMMCreateContext<float>(box_size, n, m, PVFMM_MAX_DEPTH, PVFMMKernelPtr<float>(kernel), PVFMMBndry(bndry), comm);
+  return PVFMMCreateContext<float>(box_size, n, m, sctl::MAX_DEPTH, PVFMMKernelPtr<float>(kernel), PVFMMBndry(bndry), comm);
 }
 
 void PVFMMEvalF(const float* src_pos, const float* sl_den, const float* dl_den, long n_src, const float* trg_pos, float* trg_val, long n_trg, const void* ctx, int setup) {
@@ -919,7 +919,7 @@ void PVFMMDestroyContextF(void** ctx) {
 
 
 void* PVFMMCreateContextD(double box_size, int n, int m, enum PVFMMKernel kernel, enum PVFMMBoundaryType bndry, MPI_Comm comm) {
-  return PVFMMCreateContext<double>(box_size, n, m, PVFMM_MAX_DEPTH, PVFMMKernelPtr<double>(kernel), PVFMMBndry(bndry), comm);
+  return PVFMMCreateContext<double>(box_size, n, m, sctl::MAX_DEPTH, PVFMMKernelPtr<double>(kernel), PVFMMBndry(bndry), comm);
 }
 
 void PVFMMEvalD(const double* src_pos, const double* sl_den, const double* dl_den, long n_src, const double* trg_pos, double* trg_val, long n_trg, const void* ctx, int setup) {


### PR DESCRIPTION
PVFMM_MAX_DEPTH was 30 while sctl::Morton's MAX_DEPTH defaults to 15, and pvfmm_common.hpp only reconciled the two with

    #ifndef SCTL_MAX_DEPTH
    #define SCTL_MAX_DEPTH PVFMM_MAX_DEPTH
    #endif

which is a no-op once sctl/morton.hpp has already been included. Any translation unit that includes <sctl.hpp> before pvfmm -- which is every driver reaching pvfmm through sctl::ParticleFMM -- built Morton codes with TOTAL_BITS=45 while MPI_Tree::Initialize passed depth 30. So MortonCode<3>::Ancestor() shifted by 45-90 = -45 and Morton<3>::Next() by -3, both UB. The deepest tree level got corrupt codes and its multipole expansions came out garbage, leaving the far field wrong at a subset of targets -- silently, with no memory error for ASan or SCTL_MEMDEBUG to catch.

Remove PVFMM_MAX_DEPTH and use sctl::MAX_DEPTH directly: the depth limit is a property of what sctl::Morton can encode, so there should be one name for it that cannot drift. Bump SCTL to pick up MAX_DEPTH 15 -> 20, the deepest tree that still keeps MortonInteger in a single 64-bit word (STORAGE_BITS = DIM*(MAX_DEPTH+1) = 63); 21 spills to MortonBig<2>.

On a 697k-point flat surface (bbox aspect 61) with Laplace3D_FxU at digits=8, max relative error drops from 4.6e+02 to 4.2e-08, and now converges with multipole order (1.5e-09 at digits=10, 2.5e-11 at digits=12) instead of diverging. ASan+UBSan, -O0 scalar, SCTL_MEMDEBUG, and MEMDEBUG+ASan runs are all clean.

PVFMM_MAX_DEPTH was a public macro; downstream code referencing it needs sctl::MAX_DEPTH instead. pvfmm's own examples did, and are updated here.